### PR TITLE
Release 1.7: ACP host capability and Goose adapter

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/avksp/agent-lifecycle-kit.git",
-        "ref": "v1.6.0"
+        "ref": "v1.7.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
       "source": {
         "source": "github",
         "repo": "avksp/agent-lifecycle-kit",
-        "ref": "v1.6.0"
+        "ref": "v1.7.0"
       },
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
-    "version": "1.6.0"
+    "version": "1.7.0"
   },
   "plugins": [
     {
       "name": "agent-lifecycle-kit",
       "source": ".",
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - No changes yet.
 
+## 1.7.0 - 2026-07-31
+
+- Added schema-backed neutral host capability declarations for ACP support.
+- Added fail-closed ACP probe receipts that do not start live model calls.
+- Added an EXPERIMENTAL Goose adapter descriptor, capability manifest,
+  validation tests and adapter documentation.
+
 ## 1.6.0 - 2026-07-30
 
 - Added read-only lifecycle policy proposals built from recommendation reports

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Lifecycle skills and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Provider-neutral lifecycle kit and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/cursor/.cursor-plugin/plugin.json
+++ b/adapters/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Agent lifecycle planning, budgeted execution, adapter conformance, audit, and final proof for Cursor.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/goose/README.md
+++ b/adapters/goose/README.md
@@ -1,0 +1,9 @@
+# Goose Adapter
+
+This adapter is an EXPERIMENTAL Agent Lifecycle Kit projection for the Goose
+host. It declares ACP as a neutral host capability and keeps lifecycle
+semantics in ALK core.
+
+The descriptor is validated offline. A supported ACP declaration still requires
+a host probe before use; missing executable, failed probe, or invalid invocation
+contract must fail closed.

--- a/adapters/goose/adapter.descriptor.json
+++ b/adapters/goose/adapter.descriptor.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": "agent-lifecycle-host-adapter.v1",
+  "adapterId": "goose",
+  "host": "goose",
+  "nativeProjection": "acp-host-cli",
+  "capabilityManifest": "adapters/goose/capabilities.manifest.json",
+  "maturity": "EXPERIMENTAL",
+  "liveTestedHostRange": null,
+  "contractCompatibility": {
+    "rangeKind": "closed-offline",
+    "minimum": "adapter-contract.v1",
+    "maximum": "adapter-contract.v1",
+    "authoritativeSource": {
+      "sourceId": "normalized-contract-inventory-r02",
+      "sha256": "c332a29de6eed7dcf1ff93cfa5cb0868557f31d1f7ff635ba2df2c7695ed3d4a"
+    }
+  },
+  "unsupportedOperationPolicy": "fail-closed",
+  "coreSemantics": "delegated-to-agent-lifecycle-core",
+  "hostCapabilities": [
+    {
+      "schemaVersion": "agent-host-capability.v1",
+      "capabilityId": "acp",
+      "adapterId": "goose",
+      "host": "goose",
+      "support": "supported",
+      "transport": "acp",
+      "evidencePolicy": "probe-required",
+      "providerIdentityUsed": false,
+      "probe": {
+        "required": true,
+        "command": ["goose", "--help"],
+        "liveCallsStarted": false
+      },
+      "invocationContract": {
+        "requestSchema": "agent-host-operation-request.v1",
+        "receiptSchema": "agent-host-operation-receipt.v1",
+        "unsupportedOperationPolicy": "fail-closed"
+      }
+    }
+  ],
+  "modelRouting": {
+    "status": "workflow-enforced",
+    "profileSupport": "host-local",
+    "providerModelNamesInCore": false,
+    "attemptRoutePolicy": "must-execute-or-fail-closed",
+    "usageReceiptRequired": true,
+    "unsupportedClassPolicy": "fail-closed",
+    "criticalReviewPolicy": "requires-strong-or-calibrated-local-review",
+    "liveVerified": false
+  },
+  "operations": [
+    {"name": "install", "mapping": "goose-acp-install", "offlineConformance": "synthetic"},
+    {"name": "discover", "mapping": "goose-acp-probe", "offlineConformance": "synthetic"},
+    {"name": "validate-envelope", "mapping": "core-schema-validation", "offlineConformance": "deterministic"},
+    {"name": "launch", "mapping": "goose-acp-launch", "offlineConformance": "synthetic"},
+    {"name": "model-route-execution", "mapping": "attemptModelRoute-to-host-model", "offlineConformance": "synthetic"},
+    {"name": "wait", "mapping": "goose-acp-wait", "offlineConformance": "synthetic"},
+    {"name": "cancel", "mapping": "goose-acp-cancel", "offlineConformance": "synthetic"},
+    {"name": "resume", "mapping": "workflow-state-resume", "offlineConformance": "synthetic"},
+    {"name": "tool-execution", "mapping": "goose-acp-tool-call", "offlineConformance": "synthetic"},
+    {"name": "adapter-event-stream", "mapping": "agent-adapter-event.v1", "offlineConformance": "deterministic"},
+    {"name": "result-collection", "mapping": "task-result-artifact", "offlineConformance": "deterministic"},
+    {"name": "usage-attestation", "mapping": "host-usage-ledger", "offlineConformance": "synthetic"},
+    {"name": "task-audit", "mapping": "audit-plan-implementation", "offlineConformance": "deterministic"},
+    {"name": "final-audit", "mapping": "audit-plan-implementation", "offlineConformance": "deterministic"}
+  ],
+  "eventCapture": {
+    "status": "DECLARED",
+    "portableEventSchema": "agent-adapter-event.v1",
+    "categories": [
+      "command",
+      "file-change",
+      "lifecycle-transition",
+      "model-usage",
+      "user-decision",
+      "validation"
+    ],
+    "producerBoundary": "adapter-owned",
+    "promotionRequired": false
+  }
+}

--- a/adapters/goose/capabilities.manifest.json
+++ b/adapters/goose/capabilities.manifest.json
@@ -1,0 +1,194 @@
+{
+  "adapterId": "goose",
+  "capabilities": [
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "goose-acp-install",
+      "name": "install",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "goose-acp-probe",
+      "name": "discover",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": false,
+      "mapping": "core-schema-validation",
+      "name": "validate-envelope",
+      "offlineConformance": "deterministic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "goose-acp-launch",
+      "name": "launch",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "attemptModelRoute-to-host-model",
+      "name": "model-route-execution",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "goose-acp-wait",
+      "name": "wait",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "goose-acp-cancel",
+      "name": "cancel",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "workflow-state-resume",
+      "name": "resume",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "goose-acp-tool-call",
+      "name": "tool-execution",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": false,
+      "mapping": "agent-adapter-event.v1",
+      "name": "adapter-event-stream",
+      "offlineConformance": "deterministic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": false,
+      "mapping": "task-result-artifact",
+      "name": "result-collection",
+      "offlineConformance": "deterministic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": true,
+      "mapping": "host-usage-ledger",
+      "name": "usage-attestation",
+      "offlineConformance": "synthetic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": false,
+      "mapping": "audit-plan-implementation",
+      "name": "task-audit",
+      "offlineConformance": "deterministic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    },
+    {
+      "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+      "liveEvidenceRequiredForVerified": false,
+      "mapping": "audit-plan-implementation",
+      "name": "final-audit",
+      "offlineConformance": "deterministic",
+      "support": "declared",
+      "unsupportedOperationPolicy": "fail-closed"
+    }
+  ],
+  "coreSemantics": "delegated-to-agent-lifecycle-core",
+  "descriptorDigest": "35ae7fca31d7d82a31d8d2c2648033596278bc8c803dac8845163f015dfed9ce",
+  "eventCapture": {
+    "categories": [
+      "command",
+      "file-change",
+      "lifecycle-transition",
+      "model-usage",
+      "user-decision",
+      "validation"
+    ],
+    "portableEventSchema": "agent-adapter-event.v1",
+    "producerBoundary": "adapter-owned",
+    "promotionRequired": false,
+    "status": "DECLARED"
+  },
+  "host": "goose",
+  "hostCapabilities": [
+    {
+      "adapterId": "goose",
+      "capabilityId": "acp",
+      "evidencePolicy": "probe-required",
+      "host": "goose",
+      "invocationContract": {
+        "receiptSchema": "agent-host-operation-receipt.v1",
+        "requestSchema": "agent-host-operation-request.v1",
+        "unsupportedOperationPolicy": "fail-closed"
+      },
+      "probe": {
+        "command": [
+          "goose",
+          "--help"
+        ],
+        "liveCallsStarted": false,
+        "required": true
+      },
+      "providerIdentityUsed": false,
+      "schemaVersion": "agent-host-capability.v1",
+      "support": "supported",
+      "transport": "acp"
+    }
+  ],
+  "maturity": "EXPERIMENTAL",
+  "modelRouting": {
+    "attemptRoutePolicy": "must-execute-or-fail-closed",
+    "liveVerified": false,
+    "profileSupport": "host-local",
+    "providerModelNamesInCore": false,
+    "unsupportedClassPolicy": "fail-closed",
+    "usageReceiptRequired": true
+  },
+  "promotion": {
+    "productionPromotionClaimed": false,
+    "verifiedRequiresLiveTestedHostRange": true
+  },
+  "runtimeBoundary": {
+    "hostSpecificCode": "adapter-owned",
+    "lifecycleSemantics": "delegated-to-agent-lifecycle-core",
+    "providerModelNamesInCore": false,
+    "unsupportedOperations": "fail-closed"
+  },
+  "schemaVersion": "agent-adapter-capability-manifest.v1",
+  "unsupportedOperationPolicy": "fail-closed"
+}

--- a/conformance/adapters/goose/event-stream-receipt.json
+++ b/conformance/adapters/goose/event-stream-receipt.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "agent-adapter-event-stream-receipt.v1",
+  "status": "PASS",
+  "adapterId": "goose",
+  "host": "goose",
+  "runId": "offline-conformance",
+  "taskId": "adapter-event-capture",
+  "operationId": "offline-event-capture-goose",
+  "producer": {
+    "id": "goose-neutral-event-producer",
+    "boundary": "adapter-owned",
+    "portableEventSchema": "agent-adapter-event.v1"
+  },
+  "descriptorDigest": "35ae7fca31d7d82a31d8d2c2648033596278bc8c803dac8845163f015dfed9ce",
+  "eventStreamDigest": "ebb96d43e5b99aafd88a1d708a81b9924313b5a382f1060a8e5e397fee93cebf",
+  "eventCount": 6,
+  "eventTypes": [
+    "session.started",
+    "task.launched",
+    "command.completed",
+    "writes.summarized",
+    "usage.reported",
+    "task.completed"
+  ],
+  "terminalEvent": "task.completed",
+  "emittedAt": "2026-07-31T00:17:01Z",
+  "productionPromotionClaimed": false,
+  "receiptDigest": "4ee7ae7164662931e34883497f3173ee917021f3673df9ab35c6b3a31580247c"
+}

--- a/conformance/adapters/goose/event-stream.json
+++ b/conformance/adapters/goose/event-stream.json
@@ -1,0 +1,106 @@
+[
+  {
+    "schemaVersion": "agent-adapter-event.v1",
+    "eventId": "offline-event-capture-goose-01",
+    "host": "goose",
+    "adapterId": "goose",
+    "runId": "offline-conformance",
+    "taskId": "adapter-event-capture",
+    "operationId": "offline-event-capture-goose",
+    "sequence": 1,
+    "eventType": "session.started",
+    "status": "INFO",
+    "recordedAt": "2026-07-31T00:17:00Z",
+    "payload": {
+      "category": "lifecycle-transition"
+    }
+  },
+  {
+    "schemaVersion": "agent-adapter-event.v1",
+    "eventId": "offline-event-capture-goose-02",
+    "host": "goose",
+    "adapterId": "goose",
+    "runId": "offline-conformance",
+    "taskId": "adapter-event-capture",
+    "operationId": "offline-event-capture-goose",
+    "sequence": 2,
+    "eventType": "task.launched",
+    "status": "PASS",
+    "recordedAt": "2026-07-31T00:17:00Z",
+    "payload": {
+      "category": "lifecycle-transition"
+    }
+  },
+  {
+    "schemaVersion": "agent-adapter-event.v1",
+    "eventId": "offline-event-capture-goose-03",
+    "host": "goose",
+    "adapterId": "goose",
+    "runId": "offline-conformance",
+    "taskId": "adapter-event-capture",
+    "operationId": "offline-event-capture-goose",
+    "sequence": 3,
+    "eventType": "command.completed",
+    "status": "PASS",
+    "recordedAt": "2026-07-31T00:17:00Z",
+    "payload": {
+      "category": "command",
+      "command": "agent-lifecycle adapter event-check",
+      "exitCode": 0
+    }
+  },
+  {
+    "schemaVersion": "agent-adapter-event.v1",
+    "eventId": "offline-event-capture-goose-04",
+    "host": "goose",
+    "adapterId": "goose",
+    "runId": "offline-conformance",
+    "taskId": "adapter-event-capture",
+    "operationId": "offline-event-capture-goose",
+    "sequence": 4,
+    "eventType": "writes.summarized",
+    "status": "PASS",
+    "recordedAt": "2026-07-31T00:17:00Z",
+    "payload": {
+      "category": "file-change",
+      "changedFiles": [
+        "adapters/goose/adapter.descriptor.json"
+      ]
+    }
+  },
+  {
+    "schemaVersion": "agent-adapter-event.v1",
+    "eventId": "offline-event-capture-goose-05",
+    "host": "goose",
+    "adapterId": "goose",
+    "runId": "offline-conformance",
+    "taskId": "adapter-event-capture",
+    "operationId": "offline-event-capture-goose",
+    "sequence": 5,
+    "eventType": "usage.reported",
+    "status": "PASS",
+    "recordedAt": "2026-07-31T00:17:00Z",
+    "payload": {
+      "category": "model-usage",
+      "inputTokens": 64,
+      "outputTokens": 16
+    }
+  },
+  {
+    "schemaVersion": "agent-adapter-event.v1",
+    "eventId": "offline-event-capture-goose-06",
+    "host": "goose",
+    "adapterId": "goose",
+    "runId": "offline-conformance",
+    "taskId": "adapter-event-capture",
+    "operationId": "offline-event-capture-goose",
+    "sequence": 6,
+    "eventType": "task.completed",
+    "status": "PASS",
+    "recordedAt": "2026-07-31T00:17:00Z",
+    "payload": {
+      "category": "lifecycle-transition",
+      "resultPath": "conformance/adapters/goose/offline-baseline.json"
+    }
+  }
+]

--- a/conformance/adapters/goose/offline-baseline.json
+++ b/conformance/adapters/goose/offline-baseline.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "agent-lifecycle-adapter-conformance.v1",
+  "adapterId": "goose",
+  "host": "goose",
+  "baselineId": "offline-adapter-baseline-v1",
+  "adapterDescriptor": "adapters/goose/adapter.descriptor.json",
+  "capabilityManifest": "adapters/goose/capabilities.manifest.json",
+  "sharedBaseline": "conformance/core/adapter-baseline.v1.json",
+  "requiredMaturity": "EXPERIMENTAL",
+  "liveRuntimeRequired": false,
+  "expectedResult": "PASS"
+}

--- a/docs/adapters/goose.md
+++ b/docs/adapters/goose.md
@@ -1,0 +1,28 @@
+# Goose Adapter
+
+The Goose adapter is an EXPERIMENTAL ALK adapter projection for hosts that
+provide an ACP-compatible command surface.
+
+## Files
+
+- Descriptor: `adapters/goose/adapter.descriptor.json`
+- Capability manifest: `adapters/goose/capabilities.manifest.json`
+- Offline tests: `tests/adapters/goose/test_goose_adapter.py`
+- Probe receipt tests: `tests/live_hosts/test_goose_adapter.py`
+
+## Capability Contract
+
+The descriptor declares `hostCapabilities[0].capabilityId = "acp"`. This is a
+neutral capability claim, not a provider or model identity. Lifecycle semantics
+remain delegated to ALK core, and unsupported operations use the shared
+fail-closed policy.
+
+The adapter is not marked `VERIFIED`. Promotion requires live host conformance
+and calibration evidence in a later release gate.
+
+## Validation
+
+```bash
+PYTHONPATH=src python3 -m agent_lifecycle adapter validate --descriptor adapters/goose/adapter.descriptor.json --baseline conformance/core/adapter-baseline.v1.json
+PYTHONPATH=src python3 -m pytest tests/adapters/goose tests/live_hosts/test_goose_adapter.py
+```

--- a/docs/reference/host-capabilities.md
+++ b/docs/reference/host-capabilities.md
@@ -1,0 +1,21 @@
+# Host Capabilities
+
+Host capabilities describe what a host adapter can expose to ALK without using
+host or provider identity as a shortcut for behavior.
+
+`agent-host-capability.v1` is an additive declaration carried by adapter
+descriptors and capability manifests. The first capability is `acp`, with these
+rules:
+
+- `support` is one of `supported`, `unsupported` or `unknown`.
+- `providerIdentityUsed` is always `false`.
+- `supported` requires `transport: "acp"`, `evidencePolicy:
+  "probe-required"` and an invocation contract using
+  `agent-host-operation-request.v1` plus `agent-host-operation-receipt.v1`.
+- Host probes are safe preflight checks only. They must not start live model
+  calls and are recorded with `agent-acp-probe-receipt.v1`.
+- Missing executable, failed probe or invalid invocation contract is a blocking
+  failure for a `supported` declaration.
+
+Hosts without probe evidence should be represented as `unsupported` or
+`unknown`, or omitted from the positive capability evidence set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-lifecycle-kit"
-version = "1.6.0"
+version = "1.7.0"
 description = "Provider-neutral lifecycle controller core for specification, planning, execution, validation, and audit workflows."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/agent_lifecycle/_version.py
+++ b/src/agent_lifecycle/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"

--- a/src/agent_lifecycle/contracts/adapter_contract_schemas.py
+++ b/src/agent_lifecycle/contracts/adapter_contract_schemas.py
@@ -98,6 +98,7 @@ ADAPTER_CONTRACT_SCHEMAS: dict[str, dict[str, Any]] = {
             "capabilities": {"type": "array", "items": {"type": "object"}},
             "modelRouting": {"type": "object"},
             "runtimeBoundary": {"type": "object"},
+            "hostCapabilities": {"type": "array", "items": {"type": "object"}},
             "promotion": {"type": "object"},
         },
     ),

--- a/src/agent_lifecycle/contracts/host_capability_schemas.py
+++ b/src/agent_lifecycle/contracts/host_capability_schemas.py
@@ -1,0 +1,64 @@
+"""Built-in JSON schemas for neutral host capability declarations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_lifecycle.contracts.schema_builders import open_object_schema as _open_object_schema
+
+HOST_CAPABILITY_SCHEMAS: dict[str, dict[str, Any]] = {
+    "agent-host-capability.v1": _open_object_schema(
+        "agent-host-capability.v1",
+        required=[
+            "schemaVersion",
+            "capabilityId",
+            "adapterId",
+            "host",
+            "support",
+            "transport",
+            "evidencePolicy",
+            "providerIdentityUsed",
+        ],
+        properties={
+            "capabilityId": {"type": "string", "minLength": 1},
+            "adapterId": {"type": "string", "minLength": 1},
+            "host": {"type": "string", "minLength": 1},
+            "support": {"enum": ["supported", "unsupported", "unknown"]},
+            "transport": {"enum": ["acp", "host-local", "rpc-json", "skills", "unknown"]},
+            "evidencePolicy": {"enum": ["probe-required", "not-claimed", "unknown"]},
+            "providerIdentityUsed": {"const": False},
+            "probe": {"type": ["object", "null"]},
+            "invocationContract": {"type": ["object", "null"]},
+        },
+    ),
+    "agent-host-capability-validation.v1": _open_object_schema(
+        "agent-host-capability-validation.v1",
+        required=["schemaVersion", "status", "capabilityCount", "blockers"],
+        properties={
+            "status": {"enum": ["PASS", "FAIL"]},
+            "capabilityCount": {"type": "integer", "minimum": 0},
+            "blockers": {"type": "array", "items": {"type": "object"}},
+        },
+    ),
+    "agent-acp-probe-receipt.v1": _open_object_schema(
+        "agent-acp-probe-receipt.v1",
+        required=[
+            "schemaVersion",
+            "status",
+            "adapterId",
+            "host",
+            "capabilityId",
+            "liveCallsStarted",
+            "blockers",
+        ],
+        properties={
+            "status": {"enum": ["PASS", "FAIL", "SKIPPED"]},
+            "adapterId": {"type": ["string", "null"]},
+            "host": {"type": ["string", "null"]},
+            "capabilityId": {"const": "acp"},
+            "liveCallsStarted": {"const": False},
+            "checks": {"type": "array", "items": {"type": "object"}},
+            "blockers": {"type": "array", "items": {"type": "object"}},
+        },
+    ),
+}

--- a/src/agent_lifecycle/contracts/schemas.py
+++ b/src/agent_lifecycle/contracts/schemas.py
@@ -10,6 +10,7 @@ from agent_lifecycle.contracts.adapter_event_schemas import ADAPTER_EVENT_SCHEMA
 from agent_lifecycle.contracts.context_model_schemas import CONTEXT_MODEL_SCHEMAS
 from agent_lifecycle.contracts.core_schemas import CORE_SCHEMAS
 from agent_lifecycle.contracts.evidence_import_schemas import EVIDENCE_IMPORT_SCHEMAS
+from agent_lifecycle.contracts.host_capability_schemas import HOST_CAPABILITY_SCHEMAS
 from agent_lifecycle.contracts.metric_schemas import METRIC_SCHEMAS
 from agent_lifecycle.contracts.plan_contract_schemas import PLAN_CONTRACT_SCHEMAS
 from agent_lifecycle.contracts.policy_schemas import POLICY_SCHEMAS
@@ -27,6 +28,7 @@ _SCHEMA_GROUPS = (
     EVIDENCE_IMPORT_SCHEMAS,
     STATUS_GOAL_SCHEMAS,
     RUNNER_WORKTREE_SCHEMAS,
+    HOST_CAPABILITY_SCHEMAS,
     ADAPTER_CONTRACT_SCHEMAS,
     CONTEXT_MODEL_SCHEMAS,
     RELEASE_CONTRACT_SCHEMAS,

--- a/src/agent_lifecycle/host_protocol/__init__.py
+++ b/src/agent_lifecycle/host_protocol/__init__.py
@@ -1,5 +1,12 @@
 """Provider-neutral host operation protocol."""
 
+from agent_lifecycle.host_protocol.acp_capability import (
+    build_acp_capability,
+    build_acp_probe_receipt,
+    require_host_capabilities_pass,
+    validate_host_capabilities,
+    validate_no_acp_evidence_for_hosts,
+)
 from agent_lifecycle.host_protocol.capabilities import (
     build_capability_manifest,
     validate_capability_manifest,
@@ -34,6 +41,8 @@ __all__ = [
     "HostOperationReceipt",
     "HostOperationRequest",
     "adapter_declares_event_capture",
+    "build_acp_capability",
+    "build_acp_probe_receipt",
     "build_capability_manifest",
     "build_adapter_event_stream",
     "build_event_stream_receipt",
@@ -43,6 +52,7 @@ __all__ = [
     "require_adapter_event_stream_pass",
     "require_adapter_inspection_pass",
     "require_adapter_validation_pass",
+    "require_host_capabilities_pass",
     "inspect_adapter_descriptor",
     "scaffold_adapter",
     "validate_capability_manifest",
@@ -50,4 +60,6 @@ __all__ = [
     "validate_event_capture_receipt",
     "validate_adapter_event_stream",
     "validate_adapter_descriptor",
+    "validate_host_capabilities",
+    "validate_no_acp_evidence_for_hosts",
 ]

--- a/src/agent_lifecycle/host_protocol/acp_capability.py
+++ b/src/agent_lifecycle/host_protocol/acp_capability.py
@@ -1,0 +1,195 @@
+"""Neutral ACP host capability declarations and fail-closed probe receipts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_lifecycle.contracts.errors import LifecycleError
+
+ACP_CAPABILITY_ID = "acp"
+HOST_CAPABILITY_SCHEMA_VERSION = "agent-host-capability.v1"
+HOST_CAPABILITY_VALIDATION_SCHEMA_VERSION = "agent-host-capability-validation.v1"
+ACP_PROBE_RECEIPT_SCHEMA_VERSION = "agent-acp-probe-receipt.v1"
+_SUPPORTED_VALUES = {"supported", "unsupported", "unknown"}
+
+
+def build_acp_capability(
+    *,
+    adapter_id: str,
+    host: str,
+    support: str,
+    probe_command: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a schema-backed ACP capability declaration without provider identity."""
+
+    capability: dict[str, Any] = {
+        "schemaVersion": HOST_CAPABILITY_SCHEMA_VERSION,
+        "capabilityId": ACP_CAPABILITY_ID,
+        "adapterId": adapter_id,
+        "host": host,
+        "support": support,
+        "transport": "acp" if support == "supported" else "unknown",
+        "evidencePolicy": "probe-required" if support == "supported" else "not-claimed",
+        "providerIdentityUsed": False,
+        "probe": None,
+        "invocationContract": None,
+    }
+    if support == "supported":
+        capability["probe"] = {
+            "required": True,
+            "command": list(probe_command or [host, "--help"]),
+            "liveCallsStarted": False,
+        }
+        capability["invocationContract"] = {
+            "requestSchema": "agent-host-operation-request.v1",
+            "receiptSchema": "agent-host-operation-receipt.v1",
+            "unsupportedOperationPolicy": "fail-closed",
+        }
+    return capability
+
+
+def validate_host_capabilities(
+    capabilities: Any,
+    *,
+    adapter_id: str | None = None,
+    host: str | None = None,
+) -> dict[str, Any]:
+    """Validate optional host capability declarations attached to a descriptor."""
+
+    blockers: list[dict[str, Any]] = []
+    if not isinstance(capabilities, list):
+        blockers.append({"code": "invalid-host-capabilities", "message": "hostCapabilities must be an array"})
+        return _validation_result(0, blockers)
+    for index, capability in enumerate(capabilities):
+        if not isinstance(capability, dict):
+            blockers.append({"code": "invalid-host-capability", "index": index, "message": "host capability must be an object"})
+            continue
+        _validate_capability_shape(capability, blockers, index=index, adapter_id=adapter_id, host=host)
+    return _validation_result(len(capabilities), blockers)
+
+
+def validate_no_acp_evidence_for_hosts(capabilities: list[dict[str, Any]], *, excluded_hosts: set[str]) -> dict[str, Any]:
+    """Validate that excluded hosts have no positive ACP evidence declarations."""
+
+    blockers: list[dict[str, Any]] = []
+    for capability in capabilities:
+        if capability.get("capabilityId") != ACP_CAPABILITY_ID:
+            continue
+        host = capability.get("host")
+        if isinstance(host, str) and host in excluded_hosts and capability.get("support") == "supported":
+            blockers.append({"code": "excluded-host-acp-evidence", "host": host})
+    return _validation_result(len(capabilities), blockers)
+
+
+def build_acp_probe_receipt(
+    capability: dict[str, Any],
+    *,
+    executable_found: bool,
+    probe_passed: bool,
+    invocation_contract_valid: bool,
+) -> dict[str, Any]:
+    """Return a fail-closed ACP probe receipt without starting live model calls."""
+
+    validation = validate_host_capabilities(
+        [capability],
+        adapter_id=capability.get("adapterId") if isinstance(capability.get("adapterId"), str) else None,
+        host=capability.get("host") if isinstance(capability.get("host"), str) else None,
+    )
+    blockers = list(validation["blockers"])
+    support = capability.get("support")
+    checks = [
+        {"name": "capability-declaration", "status": validation["status"]},
+        {"name": "executable-present", "status": "PASS" if executable_found else "FAIL"},
+        {"name": "acp-probe", "status": "PASS" if probe_passed else "FAIL"},
+        {"name": "invocation-contract", "status": "PASS" if invocation_contract_valid else "FAIL"},
+    ]
+    if support != "supported":
+        return {
+            "schemaVersion": ACP_PROBE_RECEIPT_SCHEMA_VERSION,
+            "status": "SKIPPED",
+            "adapterId": capability.get("adapterId"),
+            "host": capability.get("host"),
+            "capabilityId": ACP_CAPABILITY_ID,
+            "liveCallsStarted": False,
+            "checks": checks[:1],
+            "blockers": blockers,
+        }
+    if not executable_found:
+        blockers.append({"code": "acp-executable-missing"})
+    if not probe_passed:
+        blockers.append({"code": "acp-probe-failed"})
+    if not invocation_contract_valid:
+        blockers.append({"code": "acp-invocation-contract-invalid"})
+    return {
+        "schemaVersion": ACP_PROBE_RECEIPT_SCHEMA_VERSION,
+        "status": "PASS" if not blockers else "FAIL",
+        "adapterId": capability.get("adapterId"),
+        "host": capability.get("host"),
+        "capabilityId": ACP_CAPABILITY_ID,
+        "liveCallsStarted": False,
+        "checks": checks,
+        "blockers": blockers,
+    }
+
+
+def require_host_capabilities_pass(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("status") == "FAIL":
+        raise LifecycleError("host-capability-validation-failed", "host capability validation failed", {"validation": payload})
+    return payload
+
+
+def _validate_capability_shape(
+    capability: dict[str, Any],
+    blockers: list[dict[str, Any]],
+    *,
+    index: int,
+    adapter_id: str | None,
+    host: str | None,
+) -> None:
+    if capability.get("schemaVersion") != HOST_CAPABILITY_SCHEMA_VERSION:
+        blockers.append({"code": "invalid-host-capability-schema", "index": index})
+    if capability.get("capabilityId") != ACP_CAPABILITY_ID:
+        blockers.append({"code": "unsupported-host-capability", "index": index, "capabilityId": capability.get("capabilityId")})
+    if capability.get("support") not in _SUPPORTED_VALUES:
+        blockers.append({"code": "invalid-host-capability-support", "index": index})
+    if capability.get("providerIdentityUsed") is not False:
+        blockers.append({"code": "host-capability-provider-identity", "index": index})
+    if adapter_id is not None and capability.get("adapterId") != adapter_id:
+        blockers.append({"code": "host-capability-adapter-mismatch", "index": index})
+    if host is not None and capability.get("host") != host:
+        blockers.append({"code": "host-capability-host-mismatch", "index": index})
+    if capability.get("support") == "supported":
+        _validate_supported_acp(capability, blockers, index=index)
+
+
+def _validate_supported_acp(capability: dict[str, Any], blockers: list[dict[str, Any]], *, index: int) -> None:
+    if capability.get("transport") != "acp":
+        blockers.append({"code": "supported-acp-transport-mismatch", "index": index})
+    if capability.get("evidencePolicy") != "probe-required":
+        blockers.append({"code": "supported-acp-probe-policy-missing", "index": index})
+    probe = capability.get("probe")
+    if not isinstance(probe, dict) or probe.get("required") is not True:
+        blockers.append({"code": "supported-acp-probe-required", "index": index})
+    elif not isinstance(probe.get("command"), list) or not all(isinstance(item, str) and item for item in probe["command"]):
+        blockers.append({"code": "supported-acp-probe-command-invalid", "index": index})
+    elif probe.get("liveCallsStarted") is not False:
+        blockers.append({"code": "supported-acp-probe-live-call-overclaim", "index": index})
+    contract = capability.get("invocationContract")
+    if not isinstance(contract, dict):
+        blockers.append({"code": "supported-acp-invocation-contract-missing", "index": index})
+        return
+    if contract.get("requestSchema") != "agent-host-operation-request.v1":
+        blockers.append({"code": "supported-acp-request-schema", "index": index})
+    if contract.get("receiptSchema") != "agent-host-operation-receipt.v1":
+        blockers.append({"code": "supported-acp-receipt-schema", "index": index})
+    if contract.get("unsupportedOperationPolicy") != "fail-closed":
+        blockers.append({"code": "supported-acp-unsupported-policy", "index": index})
+
+
+def _validation_result(capability_count: int, blockers: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schemaVersion": HOST_CAPABILITY_VALIDATION_SCHEMA_VERSION,
+        "status": "PASS" if not blockers else "FAIL",
+        "capabilityCount": capability_count,
+        "blockers": blockers,
+    }

--- a/src/agent_lifecycle/host_protocol/capabilities.py
+++ b/src/agent_lifecycle/host_protocol/capabilities.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from agent_lifecycle.contracts import canonical_digest
+from agent_lifecycle.host_protocol.acp_capability import validate_host_capabilities
 from agent_lifecycle.host_protocol.event_capture import EVENT_CAPTURE_OPERATION, adapter_declares_event_capture, event_capture_declaration
 from agent_lifecycle.host_protocol.validation import REQUIRED_OPERATION_NAMES, validate_adapter_descriptor
 
@@ -40,6 +41,7 @@ def build_capability_manifest(descriptor: dict[str, Any]) -> dict[str, Any]:
             "unsupportedOperations": descriptor.get("unsupportedOperationPolicy"),
             "providerModelNamesInCore": model_routing.get("providerModelNamesInCore"),
         },
+        "hostCapabilities": _host_capabilities_from_descriptor(descriptor),
         "eventCapture": _event_capture_from_descriptor(descriptor),
         "promotion": {
             "verifiedRequiresLiveTestedHostRange": True,
@@ -84,6 +86,7 @@ def validate_capability_manifest(manifest: dict[str, Any], *, descriptor: dict[s
         )
     _validate_manifest_capabilities(manifest, descriptor, blockers)
     _validate_runtime_boundary(manifest, descriptor, blockers)
+    _validate_host_capability_drift(manifest, descriptor, blockers)
     _validate_event_capture(manifest, descriptor, blockers)
     status = "PASS" if not blockers else "FAIL"
     return {
@@ -120,6 +123,13 @@ def _event_capture_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]
         "producerBoundary": None,
         "promotionRequired": False,
     }
+
+
+def _host_capabilities_from_descriptor(descriptor: dict[str, Any]) -> list[dict[str, Any]]:
+    capabilities = descriptor.get("hostCapabilities")
+    if not isinstance(capabilities, list):
+        return []
+    return [dict(item) for item in capabilities if isinstance(item, dict)]
 
 
 def _validate_manifest_capabilities(
@@ -174,6 +184,29 @@ def _validate_runtime_boundary(
         blockers.append({"code": "capability-runtime-boundary-policy", "field": "unsupportedOperations"})
     if boundary.get("providerModelNamesInCore") is not False:
         blockers.append({"code": "capability-provider-model-boundary", "message": "provider model names must stay out of core contracts"})
+
+
+def _validate_host_capability_drift(
+    manifest: dict[str, Any],
+    descriptor: dict[str, Any],
+    blockers: list[dict[str, Any]],
+) -> None:
+    descriptor_capabilities = descriptor.get("hostCapabilities")
+    manifest_capabilities = manifest.get("hostCapabilities")
+    if descriptor_capabilities is None and manifest_capabilities is None:
+        return
+    if not isinstance(descriptor_capabilities, list):
+        descriptor_capabilities = []
+    if manifest_capabilities != descriptor_capabilities:
+        blockers.append({"code": "capability-manifest-host-capability-drift"})
+        return
+    validation = validate_host_capabilities(
+        manifest_capabilities,
+        adapter_id=descriptor.get("adapterId") if isinstance(descriptor.get("adapterId"), str) else None,
+        host=descriptor.get("host") if isinstance(descriptor.get("host"), str) else None,
+    )
+    if validation["status"] == "FAIL":
+        blockers.append({"code": "capability-manifest-host-capability-invalid", "blockers": validation["blockers"]})
 
 
 def _validate_event_capture(

--- a/src/agent_lifecycle/host_protocol/inspection.py
+++ b/src/agent_lifecycle/host_protocol/inspection.py
@@ -75,6 +75,7 @@ def inspect_adapter_descriptor(
             "status": "SKIPPED" if skip_host_commands else "UNKNOWN",
             "binary": _display_binary(host_bin or descriptor.get("host")),
         },
+        "hostCapabilities": descriptor.get("hostCapabilities") if isinstance(descriptor.get("hostCapabilities"), list) else [],
     }
 
     if skip_host_commands:

--- a/src/agent_lifecycle/host_protocol/validation.py
+++ b/src/agent_lifecycle/host_protocol/validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from agent_lifecycle.contracts.errors import LifecycleError
+from agent_lifecycle.host_protocol.acp_capability import validate_host_capabilities
 from agent_lifecycle.host_protocol.contracts import HostOperationReceipt, HostOperationRequest
 
 REQUIRED_DESCRIPTOR_FIELDS = {
@@ -95,6 +96,21 @@ def _validate_descriptor_shape(descriptor: dict[str, Any], blockers: list[dict[s
     missing_operations = sorted(REQUIRED_OPERATION_NAMES.difference(provided))
     if missing_operations:
         blockers.append({"code": "adapter-required-operation-missing", "message": "required operations are missing", "operations": missing_operations})
+    host_capabilities = descriptor.get("hostCapabilities")
+    if host_capabilities is not None:
+        validation = validate_host_capabilities(
+            host_capabilities,
+            adapter_id=descriptor.get("adapterId") if isinstance(descriptor.get("adapterId"), str) else None,
+            host=descriptor.get("host") if isinstance(descriptor.get("host"), str) else None,
+        )
+        if validation["status"] == "FAIL":
+            blockers.append(
+                {
+                    "code": "adapter-host-capability-invalid",
+                    "message": "adapter hostCapabilities failed validation",
+                    "blockers": validation["blockers"],
+                }
+            )
 
 
 def _validate_baseline(descriptor: dict[str, Any], baseline: dict[str, Any], blockers: list[dict[str, Any]]) -> None:

--- a/tests/adapters/goose/test_goose_adapter.py
+++ b/tests/adapters/goose/test_goose_adapter.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_lifecycle.host_protocol import (
+    build_capability_manifest,
+    validate_adapter_descriptor,
+    validate_capability_manifest,
+    validate_host_capabilities,
+)
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_descriptor_and_capability_manifest_pass_offline_contracts() -> None:
+    descriptor_path = ROOT / "adapters/goose/adapter.descriptor.json"
+    descriptor = _load_json(descriptor_path)
+    baseline = _load_json(ROOT / "conformance/core/adapter-baseline.v1.json")
+    manifest = _load_json(ROOT / "adapters/goose/capabilities.manifest.json")
+
+    assert validate_adapter_descriptor(descriptor, baseline=baseline)["status"] == "PASS"
+    assert validate_capability_manifest(manifest, descriptor=descriptor)["status"] == "PASS"
+    assert manifest == build_capability_manifest(descriptor)
+    assert manifest["adapterId"] == "goose"
+    assert manifest["hostCapabilities"][0]["capabilityId"] == "acp"
+
+
+def test_descriptor_rejects_invalid_acp_capability_claim() -> None:
+    descriptor = _load_json(ROOT / "adapters/goose/adapter.descriptor.json")
+    descriptor["hostCapabilities"][0]["providerIdentityUsed"] = True
+
+    result = validate_adapter_descriptor(descriptor)
+
+    assert result["status"] == "FAIL"
+    nested_codes = {
+        blocker["code"]
+        for item in result["blockers"]
+        if item["code"] == "adapter-host-capability-invalid"
+        for blocker in item["blockers"]
+    }
+    assert "host-capability-provider-identity" in nested_codes
+
+
+def test_goose_acp_host_capability_is_probe_required() -> None:
+    descriptor = _load_json(ROOT / "adapters/goose/adapter.descriptor.json")
+    capability = descriptor["hostCapabilities"][0]
+
+    validation = validate_host_capabilities([capability], adapter_id="goose", host="goose")
+
+    assert validation["status"] == "PASS"
+    assert capability["support"] == "supported"
+    assert capability["evidencePolicy"] == "probe-required"
+    assert capability["probe"]["liveCallsStarted"] is False
+
+
+def _load_json(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError(f"expected object: {path}")
+    return value

--- a/tests/adapters/test_publication_manifests.py
+++ b/tests/adapters/test_publication_manifests.py
@@ -8,7 +8,7 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "1.6.0"
+VERSION = "1.7.0"
 PLUGIN_NAME = "agent-lifecycle-kit"
 SKILL_NAMES = {
     "agent-first-planning",

--- a/tests/conformance/test_adapter_conformance_tool.py
+++ b/tests/conformance/test_adapter_conformance_tool.py
@@ -22,7 +22,7 @@ class AdapterConformanceToolTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0)
             self.assertEqual(payload["schemaVersion"], "agent-adapter-conformance-verification.v1")
             self.assertEqual(payload["status"], "PASS")
-            self.assertEqual(set(payload["hosts"]), {"claude", "codex", "cursor", "gemini-cli", "hermes", "kimi-code", "opencode", "qwen-code"})
+            self.assertEqual(set(payload["hosts"]), {"claude", "codex", "cursor", "gemini-cli", "goose", "hermes", "kimi-code", "opencode", "qwen-code"})
             self.assertFalse(payload["productionPromotionClaimed"])
 
     def test_tool_fails_closed_when_capability_manifest_is_missing(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+def pytest_addoption(parser):
+    parser.addoption("--operation-request", action="store", default=None)

--- a/tests/contracts/test_host_capability_schemas.py
+++ b/tests/contracts/test_host_capability_schemas.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import unittest
+
+from agent_lifecycle.contracts.schemas import get_schema, list_schemas
+
+
+class HostCapabilitySchemaTests(unittest.TestCase):
+    def test_host_capability_schemas_are_registered(self) -> None:
+        ids = {item["id"] for item in list_schemas()["schemas"]}
+
+        self.assertIn("agent-host-capability.v1", ids)
+        self.assertIn("agent-host-capability-validation.v1", ids)
+        self.assertIn("agent-acp-probe-receipt.v1", ids)
+        self.assertEqual(get_schema("agent-host-capability.v1")["properties"]["providerIdentityUsed"], {"const": False})
+        self.assertEqual(get_schema("agent-acp-probe-receipt.v1")["properties"]["liveCallsStarted"], {"const": False})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host_protocol/test_acp_capability.py
+++ b/tests/host_protocol/test_acp_capability.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import unittest
+
+from agent_lifecycle.host_protocol import (
+    build_acp_capability,
+    build_acp_probe_receipt,
+    validate_host_capabilities,
+    validate_no_acp_evidence_for_hosts,
+)
+
+
+class AcpCapabilityTests(unittest.TestCase):
+    def test_supported_acp_capability_is_neutral_and_schema_backed(self) -> None:
+        capability = build_acp_capability(adapter_id="goose", host="goose", support="supported", probe_command=["goose", "--help"])
+
+        validation = validate_host_capabilities([capability], adapter_id="goose", host="goose")
+
+        self.assertEqual(validation["status"], "PASS")
+        self.assertFalse(capability["providerIdentityUsed"])
+        self.assertEqual(capability["capabilityId"], "acp")
+        self.assertEqual(capability["invocationContract"]["unsupportedOperationPolicy"], "fail-closed")
+
+    def test_provider_identity_claim_fails_validation(self) -> None:
+        capability = build_acp_capability(adapter_id="goose", host="goose", support="supported")
+        capability["providerIdentityUsed"] = True
+
+        validation = validate_host_capabilities([capability], adapter_id="goose", host="goose")
+
+        self.assertEqual(validation["status"], "FAIL")
+        self.assertIn("host-capability-provider-identity", {item["code"] for item in validation["blockers"]})
+
+    def test_supported_acp_probe_receipt_fails_closed(self) -> None:
+        capability = build_acp_capability(adapter_id="goose", host="goose", support="supported")
+
+        receipt = build_acp_probe_receipt(
+            capability,
+            executable_found=False,
+            probe_passed=False,
+            invocation_contract_valid=False,
+        )
+
+        self.assertEqual(receipt["status"], "FAIL")
+        self.assertFalse(receipt["liveCallsStarted"])
+        self.assertIn("acp-executable-missing", {item["code"] for item in receipt["blockers"]})
+        self.assertIn("acp-probe-failed", {item["code"] for item in receipt["blockers"]})
+        self.assertIn("acp-invocation-contract-invalid", {item["code"] for item in receipt["blockers"]})
+
+    def test_excluded_hosts_have_no_positive_capability_evidence(self) -> None:
+        capability = build_acp_capability(adapter_id="blocked", host="blocked-host", support="supported")
+
+        validation = validate_no_acp_evidence_for_hosts([capability], excluded_hosts={"blocked-host"})
+
+        self.assertEqual(validation["status"], "FAIL")
+        self.assertIn("excluded-host-acp-evidence", {item["code"] for item in validation["blockers"]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/live_hosts/test_goose_adapter.py
+++ b/tests/live_hosts/test_goose_adapter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_lifecycle.host_protocol import build_acp_probe_receipt
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_goose_probe_receipt_passes_without_live_model_call_when_probe_is_valid() -> None:
+    descriptor = _load_json(ROOT / "adapters/goose/adapter.descriptor.json")
+    receipt = build_acp_probe_receipt(
+        descriptor["hostCapabilities"][0],
+        executable_found=True,
+        probe_passed=True,
+        invocation_contract_valid=True,
+    )
+
+    assert receipt["schemaVersion"] == "agent-acp-probe-receipt.v1"
+    assert receipt["status"] == "PASS"
+    assert receipt["host"] == "goose"
+    assert receipt["liveCallsStarted"] is False
+
+
+def test_goose_probe_receipt_fails_closed_on_missing_executable() -> None:
+    descriptor = _load_json(ROOT / "adapters/goose/adapter.descriptor.json")
+    receipt = build_acp_probe_receipt(
+        descriptor["hostCapabilities"][0],
+        executable_found=False,
+        probe_passed=True,
+        invocation_contract_valid=True,
+    )
+
+    assert receipt["status"] == "FAIL"
+    assert "acp-executable-missing" in {item["code"] for item in receipt["blockers"]}
+
+
+def _load_json(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError(f"expected object: {path}")
+    return value

--- a/tests/neutrality/conftest.py
+++ b/tests/neutrality/conftest.py
@@ -1,2 +1,1 @@
-def pytest_addoption(parser):
-    parser.addoption("--operation-request", action="store", default=None)
+# Shared pytest options are registered in tests/conftest.py.

--- a/tests/package/conftest.py
+++ b/tests/package/conftest.py
@@ -1,2 +1,1 @@
-def pytest_addoption(parser):
-    parser.addoption("--operation-request", action="store", default=None)
+# Shared pytest options are registered in tests/conftest.py.

--- a/tests/package/test_foundation.py
+++ b/tests/package/test_foundation.py
@@ -18,7 +18,7 @@ class FoundationTests(unittest.TestCase):
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         project = pyproject["project"]
         self.assertEqual(project["name"], "agent-lifecycle-kit")
-        self.assertEqual(project["version"], "1.6.0")
+        self.assertEqual(project["version"], "1.7.0")
         self.assertEqual(project["requires-python"], ">=3.11,<3.14")
         self.assertEqual(project["license"]["text"], "Apache-2.0")
         self.assertEqual(project["dependencies"], [])
@@ -62,7 +62,7 @@ class FoundationTests(unittest.TestCase):
         self.assertEqual(lock["requires-python"], ">=3.11,<3.14")
         packages = {package["name"]: package for package in lock["package"]}
         self.assertIn("agent-lifecycle-kit", packages)
-        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.6.0")
+        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.7.0")
 
     def test_foundation_ci_uses_stdlib_unittest(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11,<3.14"
 
 [[package]]
 name = "agent-lifecycle-kit"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- Add schema-backed neutral host capability declarations for ACP support.
- Add fail-closed ACP probe receipts that do not start live model calls.
- Add EXPERIMENTAL Goose adapter descriptor, capability manifest, conformance fixtures, tests, and docs.
- Bump package and plugin metadata to 1.7.0.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m pytest tests -q
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest discover -s tests -q
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 tools/release/validate_adapter_conformance.py --baseline conformance/core/adapter-baseline.v1.json --evidence /tmp/agent-lifecycle-adapter-conformance-r17.json
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m agent_lifecycle plan check --manifest tasks/release-1-7/plan.manifest.json --lock tasks/release-1-7/plan.lock.json
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m agent_lifecycle plan acceptance-check --manifest tasks/release-1-7/plan.manifest.json --acceptance tasks/release-1-7/acceptance-criteria.md
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src /tmp/alk-r17-build-venv.fRgceB/bin/python tests/package/run_packaging_smoke.py --dist-dir /tmp/agent-lifecycle-r17-dist.AohvRM --evidence /tmp/agent-lifecycle-r17-packaging-smoke.XXXXXX.json
- git diff --check

## Release
- Tag pushed: v1.7.0
