### PR TITLE
Release 1.11: Context import and dialect interop

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/avksp/agent-lifecycle-kit.git",
-        "ref": "v1.10.0"
+        "ref": "v1.11.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
       "source": {
         "source": "github",
         "repo": "avksp/agent-lifecycle-kit",
-        "ref": "v1.10.0"
+        "ref": "v1.11.0"
       },
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
-    "version": "1.10.0"
+    "version": "1.11.0"
   },
   "plugins": [
     {
       "name": "agent-lifecycle-kit",
       "source": ".",
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - No changes yet.
 
+## 1.11.0 - 2026-07-31
+
+- Added import dialect profiles for Constitution/ADR and AGENTS/agentskills
+  inputs while keeping imported artifacts untrusted DRAFTs.
+- Added `nativeDialectProfileDigest` provenance on planning import results and
+  candidate plan import state.
+- Added rebuildable episode indexes and bounded episode retrieval with
+  `chainVerified` or `chainUnchecked` provenance.
+- Added English and Russian documentation for import mappers and episode
+  retrieval.
+
 ## 1.10.0 - 2026-07-31
 
 - Added sandbox-boundary contracts for runtime filesystem, network, process,

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ flowchart LR
 - Optional sandbox boundary receipts for high-risk work: filesystem, network,
   process, environment and enforcement-source evidence kept separate from git
   write scope.
+- Import mapper profiles for Constitution/ADR and AGENTS/agentskills inputs;
+  imported artifacts remain untrusted drafts with dialect profile digests.
+- Lightweight episode retrieval over receipt/session summaries with digest
+  provenance and explicit `chainVerified` or `chainUnchecked` state.
 - Advisory lifecycle mode recommendations from accumulated cost reports.
 - Explicit lifecycle policy proposals with reversible apply artifacts.
 - Read-only diagnostics for the current checkout and adapter readiness.
@@ -128,6 +132,8 @@ stable and are the compact vocabulary used by the docs, tests, and receipts:
 - Evidence integrity: `agent-proof-finding.v1`,
   `agent-root-cause-evidence.v1`, `agent-fix-impact-receipt.v1`,
   `agent-receipt-hash-chain.v1`, `agent-proof-integrity-receipt.v1`.
+- Import interop: `agent-import-dialect-profile.v1`,
+  `agent-episode-index.v1`, `agent-episode-retrieval.v1`.
 - Optional quality checks: `agent-optional-quality-pack.v1`,
   `agent-behavior-check-run.v1`.
 - Diagnostics and status views: `agent-diagnostic-bundle.v1`,
@@ -150,6 +156,8 @@ Full contract details are listed in [Public contracts](docs/reference/public-con
   evidence summaries.
 - Git write scope governs repository paths; sandbox receipts govern runtime
   containment and may be `UNKNOWN` until separately verified.
+- External dialect imports and retrieved episodes are context aids only; they
+  do not replace reviewed ALK source-of-truth artifacts.
 
 ## Documentation
 
@@ -162,6 +170,8 @@ Full contract details are listed in [Public contracts](docs/reference/public-con
 - [Usage export](docs/reference/usage-export.md)
 - [Evidence integrity](docs/reference/evidence-integrity.md)
 - [Sandbox boundaries](docs/reference/sandbox-boundaries.md)
+- [Import mappers](docs/reference/import-mappers.md)
+- [Episode retrieval](docs/reference/episode-retrieval.md)
 - [Release security](docs/security/release-security.md)
 
 ## License

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Lifecycle skills and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Provider-neutral lifecycle kit and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/cursor/.cursor-plugin/plugin.json
+++ b/adapters/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Agent lifecycle planning, budgeted execution, adapter conformance, audit, and final proof for Cursor.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ and does not depend on a source project.
 - [Lifecycle cost accounting](reference/lifecycle-cost.md)
 - [Usage export](reference/usage-export.md)
 - [Evidence integrity](reference/evidence-integrity.md)
+- [Import mappers](reference/import-mappers.md)
+- [Episode retrieval](reference/episode-retrieval.md)
 - [Lifecycle policy proposals](reference/policy.md)
 - [Plan continuity](reference/plan-continuity.md)
 - [Evidence index and imports](reference/evidence-imports.md)

--- a/docs/reference/episode-retrieval.md
+++ b/docs/reference/episode-retrieval.md
@@ -1,0 +1,48 @@
+# Episode retrieval
+
+Episode retrieval is a lightweight context mechanism over explicit receipt or
+session-summary artifacts. It is rebuildable, bounded and not a source of
+truth.
+
+## Contracts
+
+- `agent-episode-index.v1`: compact episode index built from explicit artifact
+  paths.
+- `agent-episode-index-validation.v1`: structural validation for the index.
+- `agent-episode-retrieval.v1`: bounded retrieval result for a query.
+
+The index wraps the existing evidence index and preserves digest provenance for
+each episode. Results include `sourcePath`, `artifactDigest`, compact summary
+fields and chain state.
+
+## Chain awareness
+
+When an `agent-receipt-hash-chain.v1` is supplied, an episode is marked
+`chainVerified` only if the artifact path and digest match a chain entry. When
+no matching chain is available, retrieval still works but returns
+`chainUnchecked: true`.
+
+This is intentional: retrieval may help context selection, but unchecked
+retrieval is not proof.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from agent_lifecycle.context import build_episode_context
+
+context = build_episode_context(
+    Path("."),
+    ["final/final-proof.json", "reviews/task-review.json"],
+    query="regression proof",
+    max_results=4,
+)
+```
+
+## Boundaries
+
+- Episode retrieval is optional and disabled unless called explicitly.
+- It does not read arbitrary paths; callers pass repository-relative artifacts.
+- It does not return raw artifact bodies.
+- It fails closed when the result exceeds the target context budget.

--- a/docs/reference/import-mappers.md
+++ b/docs/reference/import-mappers.md
@@ -1,0 +1,50 @@
+# Import mappers
+
+Import mappers convert external planning and instruction dialects into ALK
+draft artifacts. Imported content is never trusted automatically.
+
+## Supported dialect profiles
+
+- `constitution-adr`: Constitution or ADR-style documents with principles,
+  constraints, decisions and numbered requirements.
+- `agents-agentskills`: `AGENTS.md` or agentskills-style instruction files.
+
+Each profile uses `agent-import-dialect-profile.v1` and records:
+
+- `dialectId` and `dialectKind`;
+- `sourceTrusted: false`;
+- `requiresReview: true`;
+- `freezeBlocked: true`;
+- `profileDigest`.
+
+## Import behavior
+
+Dialect imports call the same untrusted planning import path as generic imports.
+The resulting `agent-planning-import-result.v1` includes
+`nativeDialectProfileDigest`, and the candidate plan records the same digest in
+`candidatePlan.importState.nativeDialectProfileDigest`.
+
+The candidate plan remains `DRAFT` with review, audit and freeze blockers. The
+operator must run normal ALK plan review and freeze before implementation.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from agent_lifecycle.imports import (
+    import_agentskills_dialect,
+    import_constitution_adr,
+    validate_import_result,
+)
+
+result = import_constitution_adr(Path("architecture-decision.md"))
+validation = validate_import_result(result)
+```
+
+## Safety rules
+
+- External dialect input cannot bypass ALK review.
+- Local paths and obvious secret markers block import.
+- Resource caps apply before candidate generation.
+- Profile digest drift fails validation.

--- a/docs/reference/public-contracts.md
+++ b/docs/reference/public-contracts.md
@@ -67,3 +67,26 @@ scope, while sandbox receipts govern runtime filesystem, network, process,
 environment and enforcement-source evidence. `UNKNOWN` is a valid explicit
 capability state, but high-risk required policy accepts only configured passing
 sandbox statuses.
+
+## Import interop and episode retrieval
+
+The import interop surface maps external dialects into reviewed ALK draft
+artifacts. It never treats imported content as trusted source of truth.
+
+Stable schema ids:
+
+- `agent-import-dialect-profile.v1`
+- `agent-import-dialect-profile-validation.v1`
+- `agent-episode-index.v1`
+- `agent-episode-index-validation.v1`
+- `agent-episode-retrieval.v1`
+
+`agent-import-dialect-profile.v1` requires `sourceTrusted: false`,
+`requiresReview: true` and `freezeBlocked: true`. Imported artifacts can carry
+`nativeDialectProfileDigest`, but that digest is provenance, not review
+approval.
+
+`agent-episode-retrieval.v1` is a bounded context projection over explicit
+receipt/session artifacts. Results keep artifact digests and report
+`chainVerified` only when a supplied hash chain contains the same path and
+digest; otherwise they are `chainUnchecked`.

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -40,6 +40,10 @@ flowchart LR
 - Дополнительные sandbox receipts для рискованных задач: filesystem, network,
   process, environment и enforcement source фиксируются отдельно от git
   write-scope.
+- Import mapper profiles для Constitution/ADR и AGENTS/agentskills; результат
+  остаётся untrusted draft с digest dialect profile.
+- Лёгкий episode retrieval по receipt/session summaries с digest provenance и
+  явным состоянием `chainVerified` или `chainUnchecked`.
 - Рекомендации по режиму жизненного цикла строятся по накопленной статистике.
 - Предложения по настройке правил остаются рекомендательными и применяются
   только явно, с возможностью отката.
@@ -135,6 +139,8 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
 - Целостность подтверждений: `agent-proof-finding.v1`,
   `agent-root-cause-evidence.v1`, `agent-fix-impact-receipt.v1`,
   `agent-receipt-hash-chain.v1`, `agent-proof-integrity-receipt.v1`.
+- Import interop: `agent-import-dialect-profile.v1`,
+  `agent-episode-index.v1`, `agent-episode-retrieval.v1`.
 - Дополнительные проверки качества: `agent-optional-quality-pack.v1`,
   `agent-behavior-check-run.v1`.
 - Диагностика и статусы: `agent-diagnostic-bundle.v1`,
@@ -159,6 +165,8 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
   обезличенные резюме подтверждений.
 - Git write-scope ограничивает пути репозитория; sandbox receipts описывают
   runtime containment и могут оставаться `UNKNOWN` до отдельной проверки.
+- Внешние dialect imports и retrieved episodes помогают с контекстом, но не
+  заменяют проверенные ALK source-of-truth artifacts.
 
 ## Документы
 
@@ -173,6 +181,8 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
 - [Экспорт использования](reference/usage-export.md)
 - [Целостность подтверждений](reference/evidence-integrity.md)
 - [Sandbox boundaries](reference/sandbox-boundaries.md)
+- [Import mappers](reference/import-mappers.md)
+- [Episode retrieval](reference/episode-retrieval.md)
 - [Безопасность релиза](security/release-security.md)
 
 ## Лицензия

--- a/docs/ru/reference/episode-retrieval.md
+++ b/docs/ru/reference/episode-retrieval.md
@@ -1,0 +1,46 @@
+# Episode retrieval
+
+Episode retrieval — лёгкий механизм контекста поверх явно переданных receipt
+или session-summary артефактов. Он rebuildable, bounded и не является source of
+truth.
+
+## Контракты
+
+- `agent-episode-index.v1`: компактный episode index по явным artifact paths.
+- `agent-episode-index-validation.v1`: структурная проверка index.
+- `agent-episode-retrieval.v1`: ограниченный результат поиска по query.
+
+Index использует существующий evidence index и сохраняет digest provenance для
+каждого episode. Results содержат `sourcePath`, `artifactDigest`, компактное
+summary и chain state.
+
+## Chain awareness
+
+Если передан `agent-receipt-hash-chain.v1`, episode получает `chainVerified`
+только когда artifact path и digest совпадают с entry в цепочке. Если matching
+chain нет, retrieval всё равно работает, но возвращает `chainUnchecked: true`.
+
+Это важно: retrieval помогает подобрать контекст, но unchecked retrieval не
+является доказательством.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from agent_lifecycle.context import build_episode_context
+
+context = build_episode_context(
+    Path("."),
+    ["final/final-proof.json", "reviews/task-review.json"],
+    query="regression proof",
+    max_results=4,
+)
+```
+
+## Границы
+
+- Episode retrieval optional и запускается только явно.
+- Он не читает произвольные пути; caller передаёт repo-relative artifacts.
+- Он не возвращает raw artifact bodies.
+- Он fail closed, если результат превышает target context budget.

--- a/docs/ru/reference/import-mappers.md
+++ b/docs/ru/reference/import-mappers.md
@@ -1,0 +1,51 @@
+# Import mappers
+
+Import mappers переводят внешние planning/instruction dialects в draft
+артефакты ALK. Импортированный контент никогда не считается доверенным
+автоматически.
+
+## Поддерживаемые dialect profiles
+
+- `constitution-adr`: документы в стиле Constitution или ADR с principles,
+  constraints, decisions и numbered requirements.
+- `agents-agentskills`: файлы `AGENTS.md` или инструкции в стиле agentskills.
+
+Каждый профиль использует `agent-import-dialect-profile.v1` и фиксирует:
+
+- `dialectId` и `dialectKind`;
+- `sourceTrusted: false`;
+- `requiresReview: true`;
+- `freezeBlocked: true`;
+- `profileDigest`.
+
+## Поведение импорта
+
+Dialect imports используют тот же untrusted planning import path, что и
+обычный импорт. Результат `agent-planning-import-result.v1` содержит
+`nativeDialectProfileDigest`, а candidate plan записывает этот же digest в
+`candidatePlan.importState.nativeDialectProfileDigest`.
+
+Candidate plan остаётся `DRAFT` с обязательными review, audit и freeze gates.
+Перед реализацией оператор должен пройти обычный ALK review и freeze.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from agent_lifecycle.imports import (
+    import_agentskills_dialect,
+    import_constitution_adr,
+    validate_import_result,
+)
+
+result = import_constitution_adr(Path("architecture-decision.md"))
+validation = validate_import_result(result)
+```
+
+## Safety rules
+
+- Внешний dialect input не может обойти ALK review.
+- Локальные пути и явные secret markers блокируют импорт.
+- Resource caps применяются до генерации candidate plan.
+- Drift `profileDigest` приводит к FAIL.

--- a/docs/ru/reference/public-contracts.md
+++ b/docs/ru/reference/public-contracts.md
@@ -24,6 +24,9 @@
 - `agent-sandbox-requirement.v1`: fail-closed политика обязательного sandbox
   evidence для high-risk задач.
 - `agent-sandbox-capability.v1`: декларация sandbox capabilities адаптера.
+- `agent-import-dialect-profile.v1`: профиль внешнего dialect import.
+- `agent-episode-index.v1`: rebuildable индекс receipt/session episodes.
+- `agent-episode-retrieval.v1`: bounded retrieval result с digest provenance.
 - `agent-lifecycle-policy-proposal.v1`: предложение по настройке правил.
 
 ## Правило совместимости
@@ -41,3 +44,12 @@ check`. Изменение контракта без тестов и докум�
 в репозитории, а sandbox receipt описывает runtime containment. `UNKNOWN` —
 валидное явное состояние capability, но required high-risk policy принимает
 только настроенные passing statuses, по умолчанию `PASS`.
+
+`agent-import-dialect-profile.v1` требует `sourceTrusted: false`,
+`requiresReview: true` и `freezeBlocked: true`. `nativeDialectProfileDigest`
+фиксирует provenance импортированного dialect, но не означает approval.
+
+`agent-episode-retrieval.v1` возвращает bounded context projection по явно
+переданным receipt/session artifacts. Result получает `chainVerified` только
+при совпадении path и digest с hash-chain entry; иначе state остаётся
+`chainUnchecked`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-lifecycle-kit"
-version = "1.10.0"
+version = "1.11.0"
 description = "Provider-neutral lifecycle controller core for specification, planning, execution, validation, and audit workflows."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/agent_lifecycle/_version.py
+++ b/src/agent_lifecycle/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/src/agent_lifecycle/context/__init__.py
+++ b/src/agent_lifecycle/context/__init__.py
@@ -1,9 +1,11 @@
 """Compact context rendering for small-context hosts."""
 
+from agent_lifecycle.context.episode_retrieval import build_episode_context
 from agent_lifecycle.context.profiles import load_context_profile, validate_context_profile
 from agent_lifecycle.context.rendering import check_context, render_context
 
 __all__ = [
+    "build_episode_context",
     "check_context",
     "load_context_profile",
     "render_context",

--- a/src/agent_lifecycle/context/episode_retrieval.py
+++ b/src/agent_lifecycle/context/episode_retrieval.py
@@ -1,0 +1,23 @@
+"""Context-oriented episode retrieval helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent_lifecycle.evidence_index import build_episode_index, retrieve_episodes
+
+
+def build_episode_context(
+    project_root: Path,
+    artifact_paths: list[str],
+    *,
+    query: str = "",
+    hash_chain: dict[str, Any] | None = None,
+    max_results: int = 8,
+    target_tokens: int = 2048,
+) -> dict[str, Any]:
+    """Build and query a bounded episode context from explicit artifacts."""
+
+    index = build_episode_index(project_root, artifact_paths, hash_chain=hash_chain, target_tokens=target_tokens)
+    return retrieve_episodes(index, query=query, max_results=max_results, target_tokens=target_tokens)

--- a/src/agent_lifecycle/contracts/evidence_import_schemas.py
+++ b/src/agent_lifecycle/contracts/evidence_import_schemas.py
@@ -86,6 +86,8 @@ EVIDENCE_IMPORT_SCHEMAS: dict[str, dict[str, Any]] = {
             "reviewGates": {"type": "array", "items": {"type": "string"}},
             "resourceCaps": {"type": "object"},
             "source": {"type": "object"},
+            "nativeDialectProfileDigest": {"type": ["string", "null"], "minLength": 64, "maxLength": 64},
+            "dialectProfile": {"type": ["object", "null"]},
             "candidatePlan": {"type": ["object", "null"]},
             "requiresReview": {"const": True},
             "auditRequired": {"const": True},

--- a/src/agent_lifecycle/contracts/import_dialect_schemas.py
+++ b/src/agent_lifecycle/contracts/import_dialect_schemas.py
@@ -1,0 +1,103 @@
+"""Built-in JSON schemas for import dialect and episode retrieval contracts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_lifecycle.contracts.schema_builders import open_object_schema
+
+IMPORT_DIALECT_SCHEMAS: dict[str, dict[str, Any]] = {
+    "agent-import-dialect-profile.v1": open_object_schema(
+        "agent-import-dialect-profile.v1",
+        required=[
+            "schemaVersion",
+            "dialectId",
+            "dialectKind",
+            "sourceTrusted",
+            "requiresReview",
+            "freezeBlocked",
+            "profileDigest",
+        ],
+        properties={
+            "dialectId": {"type": "string", "minLength": 1},
+            "dialectKind": {"type": "string", "minLength": 1},
+            "sourceTrusted": {"const": False},
+            "requiresReview": {"const": True},
+            "freezeBlocked": {"const": True},
+            "markers": {"type": "array", "items": {"type": "string", "minLength": 1}},
+            "resourceCaps": {"type": "object"},
+            "profileDigest": {"type": "string", "minLength": 64, "maxLength": 64},
+        },
+    ),
+    "agent-import-dialect-profile-validation.v1": open_object_schema(
+        "agent-import-dialect-profile-validation.v1",
+        required=["schemaVersion", "status", "dialectId", "dialectKind", "blockers", "profileDigest", "validationDigest"],
+        properties={
+            "status": {"enum": ["PASS", "FAIL"]},
+            "dialectId": {"type": ["string", "null"]},
+            "dialectKind": {"type": ["string", "null"]},
+            "blockers": {"type": "array", "items": {"type": "object"}},
+            "profileDigest": {"type": ["string", "null"], "minLength": 64, "maxLength": 64},
+            "validationDigest": {"type": "string", "minLength": 64, "maxLength": 64},
+        },
+    ),
+    "agent-episode-index.v1": open_object_schema(
+        "agent-episode-index.v1",
+        required=[
+            "schemaVersion",
+            "status",
+            "sourceOfTruth",
+            "rebuildable",
+            "enabledByDefault",
+            "episodeCount",
+            "episodes",
+            "blockers",
+            "indexDigest",
+        ],
+        properties={
+            "status": {"enum": ["PASS", "FAIL"]},
+            "sourceOfTruth": {"const": False},
+            "rebuildable": {"const": True},
+            "enabledByDefault": {"const": False},
+            "episodeCount": {"type": "integer", "minimum": 0},
+            "episodes": {"type": "array", "items": {"type": "object"}},
+            "blockers": {"type": "array", "items": {"type": "object"}},
+            "indexDigest": {"type": "string", "minLength": 64, "maxLength": 64},
+        },
+    ),
+    "agent-episode-index-validation.v1": open_object_schema(
+        "agent-episode-index-validation.v1",
+        required=["schemaVersion", "status", "episodeCount", "blockers", "indexDigest", "validationDigest"],
+        properties={
+            "status": {"enum": ["PASS", "FAIL"]},
+            "episodeCount": {"type": "integer", "minimum": 0},
+            "blockers": {"type": "array", "items": {"type": "object"}},
+            "indexDigest": {"type": ["string", "null"], "minLength": 64, "maxLength": 64},
+            "validationDigest": {"type": "string", "minLength": 64, "maxLength": 64},
+        },
+    ),
+    "agent-episode-retrieval.v1": open_object_schema(
+        "agent-episode-retrieval.v1",
+        required=[
+            "schemaVersion",
+            "status",
+            "sourceOfTruth",
+            "query",
+            "resultCount",
+            "results",
+            "indexDigest",
+            "blockers",
+            "retrievalDigest",
+        ],
+        properties={
+            "status": {"enum": ["PASS", "FAIL"]},
+            "sourceOfTruth": {"const": False},
+            "query": {"type": "string"},
+            "resultCount": {"type": "integer", "minimum": 0},
+            "results": {"type": "array", "items": {"type": "object"}},
+            "indexDigest": {"type": ["string", "null"], "minLength": 64, "maxLength": 64},
+            "blockers": {"type": "array", "items": {"type": "object"}},
+            "retrievalDigest": {"type": "string", "minLength": 64, "maxLength": 64},
+        },
+    ),
+}

--- a/src/agent_lifecycle/contracts/schemas.py
+++ b/src/agent_lifecycle/contracts/schemas.py
@@ -11,6 +11,7 @@ from agent_lifecycle.contracts.context_model_schemas import CONTEXT_MODEL_SCHEMA
 from agent_lifecycle.contracts.core_schemas import CORE_SCHEMAS
 from agent_lifecycle.contracts.evidence_import_schemas import EVIDENCE_IMPORT_SCHEMAS
 from agent_lifecycle.contracts.host_capability_schemas import HOST_CAPABILITY_SCHEMAS
+from agent_lifecycle.contracts.import_dialect_schemas import IMPORT_DIALECT_SCHEMAS
 from agent_lifecycle.contracts.metric_schemas import METRIC_SCHEMAS
 from agent_lifecycle.contracts.plan_contract_schemas import PLAN_CONTRACT_SCHEMAS
 from agent_lifecycle.contracts.policy_schemas import POLICY_SCHEMAS
@@ -29,6 +30,7 @@ _SCHEMA_GROUPS = (
     ADAPTER_EVENT_SCHEMAS,
     REVIEW_QUALITY_SCHEMAS,
     EVIDENCE_IMPORT_SCHEMAS,
+    IMPORT_DIALECT_SCHEMAS,
     STATUS_GOAL_SCHEMAS,
     RUNNER_WORKTREE_SCHEMAS,
     SANDBOX_SCHEMAS,

--- a/src/agent_lifecycle/evidence_index/__init__.py
+++ b/src/agent_lifecycle/evidence_index/__init__.py
@@ -7,11 +7,23 @@ from agent_lifecycle.evidence_index.core import (
     search_evidence_index,
     validate_evidence_index,
 )
+from agent_lifecycle.evidence_index.episode_index import (
+    build_episode_index,
+    require_episode_index_pass,
+    require_episode_retrieval_pass,
+    retrieve_episodes,
+    validate_episode_index,
+)
 
 __all__ = [
     "build_evidence_index",
+    "build_episode_index",
+    "require_episode_index_pass",
     "require_evidence_index_pass",
     "require_evidence_search_pass",
+    "require_episode_retrieval_pass",
+    "retrieve_episodes",
     "search_evidence_index",
+    "validate_episode_index",
     "validate_evidence_index",
 ]

--- a/src/agent_lifecycle/evidence_index/episode_index.py
+++ b/src/agent_lifecycle/evidence_index/episode_index.py
@@ -1,0 +1,275 @@
+"""Lightweight episode indexes over receipt and session summaries."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_lifecycle.context.rendering import estimate_tokens
+from agent_lifecycle.contracts import LifecycleError, canonical_digest
+from agent_lifecycle.evidence_index.core import build_evidence_index, validate_evidence_index
+
+EPISODE_INDEX_SCHEMA = "agent-episode-index.v1"
+EPISODE_INDEX_VALIDATION_SCHEMA = "agent-episode-index-validation.v1"
+EPISODE_RETRIEVAL_SCHEMA = "agent-episode-retrieval.v1"
+
+
+def build_episode_index(
+    project_root: Path,
+    artifact_paths: list[str],
+    *,
+    hash_chain: dict[str, Any] | None = None,
+    max_artifacts: int = 64,
+    max_input_bytes: int = 65536,
+    target_tokens: int = 2048,
+) -> dict[str, Any]:
+    """Build a compact, rebuildable episode index from explicit artifacts."""
+
+    evidence_index = build_evidence_index(
+        project_root,
+        artifact_paths,
+        max_artifacts=max_artifacts,
+        max_input_bytes=max_input_bytes,
+        target_tokens=target_tokens,
+    )
+    evidence_validation = validate_evidence_index(evidence_index)
+    chain_entries = _chain_entries(hash_chain)
+    episodes = [
+        _episode_from_entry(entry, chain_entries=chain_entries)
+        for entry in evidence_index.get("entries", [])
+        if isinstance(entry, dict)
+    ]
+    blockers: list[dict[str, Any]] = []
+    if evidence_validation["status"] != "PASS":
+        blockers.append({"code": "episode-source-index-invalid", "validation": evidence_validation})
+    body = {
+        "schemaVersion": EPISODE_INDEX_SCHEMA,
+        "status": "PASS",
+        "sourceOfTruth": False,
+        "rebuildable": True,
+        "enabledByDefault": False,
+        "resourceCaps": {
+            "maxArtifacts": max_artifacts,
+            "maxInputBytes": max_input_bytes,
+            "targetTokens": target_tokens,
+        },
+        "episodeCount": len(episodes),
+        "episodes": episodes,
+        "sourceIndexDigest": evidence_index.get("indexDigest"),
+        "hashChainDigest": hash_chain.get("chainDigest") if isinstance(hash_chain, dict) else None,
+        "blockers": blockers,
+    }
+    body["estimatedTokens"] = estimate_tokens(body)
+    if body["estimatedTokens"] > target_tokens:
+        body["blockers"].append(
+            {
+                "code": "episode-index-target-tokens-exceeded",
+                "estimatedTokens": body["estimatedTokens"],
+                "targetTokens": target_tokens,
+            }
+        )
+    if body["blockers"]:
+        body["status"] = "FAIL"
+    return {**body, "indexDigest": canonical_digest(body)}
+
+
+def validate_episode_index(index: dict[str, Any]) -> dict[str, Any]:
+    blockers: list[dict[str, Any]] = []
+    if not isinstance(index, dict):
+        raise LifecycleError("invalid-episode-index", "episode index must be an object")
+    if index.get("schemaVersion") != EPISODE_INDEX_SCHEMA:
+        blockers.append({"code": "episode-index-schema-invalid"})
+    if index.get("sourceOfTruth") is not False:
+        blockers.append({"code": "episode-index-source-of-truth"})
+    if index.get("rebuildable") is not True:
+        blockers.append({"code": "episode-index-not-rebuildable"})
+    if index.get("enabledByDefault") is not False:
+        blockers.append({"code": "episode-index-default-enabled"})
+    episodes = index.get("episodes")
+    if not isinstance(episodes, list):
+        blockers.append({"code": "episode-index-episodes-invalid"})
+        episodes = []
+    for item_index, episode in enumerate(episodes):
+        _validate_episode(episode, item_index, blockers)
+    if index.get("episodeCount") != len(episodes):
+        blockers.append({"code": "episode-index-count-mismatch"})
+    expected_digest = canonical_digest({key: value for key, value in index.items() if key != "indexDigest"})
+    if index.get("indexDigest") != expected_digest:
+        blockers.append({"code": "episode-index-digest-mismatch"})
+    body = {
+        "schemaVersion": EPISODE_INDEX_VALIDATION_SCHEMA,
+        "status": "PASS" if not blockers else "FAIL",
+        "episodeCount": len(episodes),
+        "blockers": blockers,
+        "indexDigest": index.get("indexDigest"),
+    }
+    return {**body, "validationDigest": canonical_digest(body)}
+
+
+def retrieve_episodes(
+    index: dict[str, Any],
+    *,
+    query: str = "",
+    max_results: int = 8,
+    target_tokens: int = 2048,
+) -> dict[str, Any]:
+    """Return bounded episode retrieval results with chain provenance."""
+
+    _positive_int(max_results, "maxResults")
+    _positive_int(target_tokens, "targetTokens")
+    validation = validate_episode_index(index)
+    episodes = index.get("episodes") if isinstance(index.get("episodes"), list) else []
+    ranked = _rank_episodes([item for item in episodes if isinstance(item, dict)], query)
+    results = [_retrieval_projection(item) for item in ranked[:max_results]]
+    body = {
+        "schemaVersion": EPISODE_RETRIEVAL_SCHEMA,
+        "status": "PASS",
+        "sourceOfTruth": False,
+        "query": query,
+        "resultCount": len(results),
+        "maxResults": max_results,
+        "results": results,
+        "omittedResultCount": max(0, len(ranked) - len(results)),
+        "indexDigest": index.get("indexDigest"),
+        "blockers": [] if validation["status"] == "PASS" else [{"code": "episode-index-invalid"}],
+        "chainStateCounts": _chain_state_counts(results),
+    }
+    body["estimatedTokens"] = estimate_tokens(body)
+    body["targetTokens"] = target_tokens
+    if body["estimatedTokens"] > target_tokens:
+        body["blockers"].append(
+            {
+                "code": "episode-retrieval-target-tokens-exceeded",
+                "estimatedTokens": body["estimatedTokens"],
+                "targetTokens": target_tokens,
+            }
+        )
+    if body["blockers"]:
+        body["status"] = "FAIL"
+    return {**body, "retrievalDigest": canonical_digest(body)}
+
+
+def require_episode_index_pass(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("status") != "PASS":
+        raise LifecycleError("episode-index-failed", "episode index validation failed", {"index": payload})
+    return payload
+
+
+def require_episode_retrieval_pass(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("status") != "PASS":
+        raise LifecycleError("episode-retrieval-failed", "episode retrieval failed", {"retrieval": payload})
+    return payload
+
+
+def _episode_from_entry(entry: dict[str, Any], *, chain_entries: dict[tuple[str, str], str]) -> dict[str, Any]:
+    path = str(entry.get("sourcePath"))
+    digest = str(entry.get("artifactDigest"))
+    chain_entry_hash = chain_entries.get((path, digest))
+    chain_state = "chainVerified" if chain_entry_hash else "chainUnchecked"
+    summary = entry.get("summary") if isinstance(entry.get("summary"), dict) else {}
+    return {
+        "episodeId": f"episode-{canonical_digest({'path': path, 'digest': digest})[:16]}",
+        "sourcePath": path,
+        "artifactDigest": digest,
+        "artifactType": entry.get("artifactType"),
+        "status": summary.get("status"),
+        "summary": _compact_summary(summary),
+        "provenance": {
+            "sourceIndexEntryDigest": canonical_digest(entry),
+            "chainState": chain_state,
+            "chainUnchecked": chain_state != "chainVerified",
+            "chainEntryHash": chain_entry_hash,
+        },
+    }
+
+
+def _chain_entries(hash_chain: dict[str, Any] | None) -> dict[tuple[str, str], str]:
+    if not isinstance(hash_chain, dict):
+        return {}
+    entries = hash_chain.get("entries")
+    if not isinstance(entries, list):
+        return {}
+    result: dict[tuple[str, str], str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        artifact = entry.get("artifact")
+        if not isinstance(artifact, dict):
+            continue
+        path = artifact.get("path")
+        digest = artifact.get("digest")
+        entry_hash = entry.get("entryHash")
+        if isinstance(path, str) and isinstance(digest, str) and isinstance(entry_hash, str):
+            result[(path, digest)] = entry_hash
+    return result
+
+
+def _validate_episode(episode: Any, index: int, blockers: list[dict[str, Any]]) -> None:
+    if not isinstance(episode, dict):
+        blockers.append({"code": "episode-entry-invalid", "index": index})
+        return
+    for key in ("episodeId", "sourcePath", "artifactDigest", "artifactType", "provenance"):
+        if key not in episode:
+            blockers.append({"code": "episode-field-missing", "index": index, "field": key})
+    provenance = episode.get("provenance")
+    if not isinstance(provenance, dict):
+        blockers.append({"code": "episode-provenance-invalid", "index": index})
+        return
+    if provenance.get("chainState") not in {"chainVerified", "chainUnchecked"}:
+        blockers.append({"code": "episode-chain-state-invalid", "index": index})
+    if provenance.get("chainState") == "chainVerified" and provenance.get("chainUnchecked") is not False:
+        blockers.append({"code": "episode-chain-verified-unchecked-mismatch", "index": index})
+    if provenance.get("chainState") == "chainUnchecked" and provenance.get("chainUnchecked") is not True:
+        blockers.append({"code": "episode-chain-unchecked-mismatch", "index": index})
+
+
+def _rank_episodes(episodes: list[dict[str, Any]], query: str) -> list[dict[str, Any]]:
+    terms = [term for term in query.lower().split() if term]
+    if not terms:
+        return sorted(episodes, key=lambda item: str(item.get("sourcePath")))
+    ranked: list[tuple[int, str, dict[str, Any]]] = []
+    for episode in episodes:
+        haystack = json.dumps(_retrieval_projection(episode), ensure_ascii=False, sort_keys=True).lower()
+        score = sum(1 for term in terms if term in haystack)
+        if score:
+            ranked.append((score, str(episode.get("sourcePath")), episode))
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    return [episode for _, _, episode in ranked]
+
+
+def _retrieval_projection(episode: dict[str, Any]) -> dict[str, Any]:
+    provenance = episode.get("provenance") if isinstance(episode.get("provenance"), dict) else {}
+    return {
+        "episodeId": episode.get("episodeId"),
+        "sourcePath": episode.get("sourcePath"),
+        "artifactType": episode.get("artifactType"),
+        "status": episode.get("status"),
+        "summary": episode.get("summary"),
+        "chainState": provenance.get("chainState"),
+        "chainUnchecked": provenance.get("chainUnchecked"),
+        "chainEntryHash": provenance.get("chainEntryHash"),
+    }
+
+
+def _compact_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in summary.items()
+        if key in {"schemaVersion", "status", "packageId", "runId", "taskId", "operationId", "adapterId", "host", "topLevelKeys"}
+    }
+
+
+def _chain_state_counts(results: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {"chainVerified": 0, "chainUnchecked": 0}
+    for item in results:
+        state = item.get("chainState")
+        if state in counts:
+            counts[state] += 1
+    return counts
+
+
+def _positive_int(value: int, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise LifecycleError("invalid-episode-retrieval", f"{label} must be a positive integer")
+    return value

--- a/src/agent_lifecycle/imports/__init__.py
+++ b/src/agent_lifecycle/imports/__init__.py
@@ -1,5 +1,16 @@
 """Optional import helpers for untrusted planning inputs."""
 
+from agent_lifecycle.imports.agentskills_profile import (
+    agentskills_profile,
+    import_agentskills_dialect,
+    validate_agentskills_profile,
+)
+from agent_lifecycle.imports.constitution_adr import (
+    constitution_adr_profile,
+    import_constitution_adr,
+    require_dialect_profile_pass,
+    validate_dialect_profile,
+)
 from agent_lifecycle.imports.planning import (
     import_planning_input,
     require_import_validation_pass,
@@ -9,9 +20,16 @@ from agent_lifecycle.imports.planning import (
 )
 
 __all__ = [
+    "agentskills_profile",
+    "constitution_adr_profile",
+    "import_agentskills_dialect",
+    "import_constitution_adr",
     "import_planning_input",
+    "require_dialect_profile_pass",
     "require_import_validation_pass",
     "require_skill_proposal_pass",
+    "validate_agentskills_profile",
+    "validate_dialect_profile",
     "validate_import_result",
     "validate_skill_improvement_proposal",
 ]

--- a/src/agent_lifecycle/imports/agentskills_profile.py
+++ b/src/agent_lifecycle/imports/agentskills_profile.py
@@ -1,0 +1,54 @@
+"""AGENTS.md and agentskills dialect import helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent_lifecycle.contracts import canonical_digest
+from agent_lifecycle.imports.constitution_adr import DIALECT_PROFILE_SCHEMA, validate_dialect_profile
+from agent_lifecycle.imports.planning import DEFAULT_MAX_INPUT_BYTES, DEFAULT_TARGET_TOKENS, import_planning_input
+
+
+def agentskills_profile(
+    *,
+    max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+) -> dict[str, Any]:
+    body = {
+        "schemaVersion": DIALECT_PROFILE_SCHEMA,
+        "dialectId": "agents-agentskills",
+        "dialectKind": "agentskills",
+        "sourceTrusted": False,
+        "requiresReview": True,
+        "freezeBlocked": True,
+        "markers": ["AGENTS.md", "agentskills", "skill", "instruction", "agent"],
+        "resourceCaps": {"maxInputBytes": max_input_bytes, "targetTokens": target_tokens},
+        "mapping": {
+            "title": ["h1", "name", "skill name"],
+            "requirements": ["rules", "instructions", "capabilities", "do-not-do bullets"],
+            "candidateStatus": "DRAFT",
+        },
+    }
+    return {**body, "profileDigest": canonical_digest(body)}
+
+
+def import_agentskills_dialect(
+    source_path: Path,
+    *,
+    package_id: str = "agentskills-import",
+    max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+) -> dict[str, Any]:
+    profile = agentskills_profile(max_input_bytes=max_input_bytes, target_tokens=target_tokens)
+    return import_planning_input(
+        source_path,
+        package_id=package_id,
+        max_input_bytes=max_input_bytes,
+        target_tokens=target_tokens,
+        dialect_profile=profile,
+    )
+
+
+def validate_agentskills_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    return validate_dialect_profile(profile)

--- a/src/agent_lifecycle/imports/constitution_adr.py
+++ b/src/agent_lifecycle/imports/constitution_adr.py
@@ -1,0 +1,91 @@
+"""Constitution/ADR dialect import helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent_lifecycle.contracts import LifecycleError, canonical_digest
+from agent_lifecycle.imports.planning import DEFAULT_MAX_INPUT_BYTES, DEFAULT_TARGET_TOKENS, import_planning_input
+
+DIALECT_PROFILE_SCHEMA = "agent-import-dialect-profile.v1"
+DIALECT_PROFILE_VALIDATION_SCHEMA = "agent-import-dialect-profile-validation.v1"
+
+
+def constitution_adr_profile(
+    *,
+    max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+) -> dict[str, Any]:
+    body = {
+        "schemaVersion": DIALECT_PROFILE_SCHEMA,
+        "dialectId": "constitution-adr",
+        "dialectKind": "constitution-adr",
+        "sourceTrusted": False,
+        "requiresReview": True,
+        "freezeBlocked": True,
+        "markers": ["constitution", "adr", "decision", "constraints", "principles"],
+        "resourceCaps": {"maxInputBytes": max_input_bytes, "targetTokens": target_tokens},
+        "mapping": {
+            "title": ["h1", "title"],
+            "requirements": ["principles", "constraints", "decision bullets", "numbered decisions"],
+            "candidateStatus": "DRAFT",
+        },
+    }
+    return {**body, "profileDigest": canonical_digest(body)}
+
+
+def import_constitution_adr(
+    source_path: Path,
+    *,
+    package_id: str = "constitution-adr-import",
+    max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+) -> dict[str, Any]:
+    profile = constitution_adr_profile(max_input_bytes=max_input_bytes, target_tokens=target_tokens)
+    return import_planning_input(
+        source_path,
+        package_id=package_id,
+        max_input_bytes=max_input_bytes,
+        target_tokens=target_tokens,
+        dialect_profile=profile,
+    )
+
+
+def validate_dialect_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    blockers: list[dict[str, Any]] = []
+    if not isinstance(profile, dict):
+        raise LifecycleError("invalid-dialect-profile", "dialect profile must be an object")
+    if profile.get("schemaVersion") != DIALECT_PROFILE_SCHEMA:
+        blockers.append({"code": "dialect-profile-schema-invalid"})
+    if not isinstance(profile.get("dialectId"), str) or not profile["dialectId"]:
+        blockers.append({"code": "dialect-profile-id-missing"})
+    if not isinstance(profile.get("dialectKind"), str) or not profile["dialectKind"]:
+        blockers.append({"code": "dialect-profile-kind-missing"})
+    if profile.get("sourceTrusted") is not False:
+        blockers.append({"code": "dialect-profile-source-trusted"})
+    if profile.get("requiresReview") is not True:
+        blockers.append({"code": "dialect-profile-review-not-required"})
+    if profile.get("freezeBlocked") is not True:
+        blockers.append({"code": "dialect-profile-freeze-not-blocked"})
+    markers = profile.get("markers")
+    if markers is not None and (not isinstance(markers, list) or not all(isinstance(item, str) and item for item in markers)):
+        blockers.append({"code": "dialect-profile-markers-invalid"})
+    expected_digest = canonical_digest({key: value for key, value in profile.items() if key != "profileDigest"})
+    if profile.get("profileDigest") != expected_digest:
+        blockers.append({"code": "dialect-profile-digest-mismatch"})
+    body = {
+        "schemaVersion": DIALECT_PROFILE_VALIDATION_SCHEMA,
+        "status": "PASS" if not blockers else "FAIL",
+        "dialectId": profile.get("dialectId"),
+        "dialectKind": profile.get("dialectKind"),
+        "blockers": blockers,
+        "profileDigest": profile.get("profileDigest"),
+    }
+    return {**body, "validationDigest": canonical_digest(body)}
+
+
+def require_dialect_profile_pass(validation: dict[str, Any]) -> dict[str, Any]:
+    if validation.get("status") != "PASS":
+        raise LifecycleError("dialect-profile-validation-failed", "dialect profile validation failed", {"validation": validation})
+    return validation

--- a/src/agent_lifecycle/imports/planning.py
+++ b/src/agent_lifecycle/imports/planning.py
@@ -40,11 +40,13 @@ def import_planning_input(
     package_id: str = "imported-plan",
     max_input_bytes: int = DEFAULT_MAX_INPUT_BYTES,
     target_tokens: int = DEFAULT_TARGET_TOKENS,
+    dialect_profile: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a draft ALK candidate from an explicit untrusted input file."""
 
     _check_positive_cap(max_input_bytes, "maxInputBytes")
     _check_positive_cap(target_tokens, "targetTokens")
+    native_dialect_profile_digest = _profile_digest(dialect_profile)
     blockers: list[dict[str, Any]] = []
     if not source_path.is_file():
         blockers.append({"code": "planning-import-source-missing", "sourceLabel": source_path.name})
@@ -58,7 +60,18 @@ def import_planning_input(
             data = source_path.read_bytes()
     text = _decode_text(data, blockers) if data and len(data) <= max_input_bytes else ""
     blockers.extend(_content_blockers(text))
-    candidate = _candidate_plan(text, data, package_id=package_id, source_label=source_path.name) if text and not blockers else None
+    candidate = (
+        _candidate_plan(
+            text,
+            data,
+            package_id=package_id,
+            source_label=source_path.name,
+            native_dialect_profile_digest=native_dialect_profile_digest,
+            dialect_profile=dialect_profile,
+        )
+        if text and not blockers
+        else None
+    )
     if text and candidate is None and not blockers:
         blockers.append({"code": "planning-import-requirements-missing"})
     body = {
@@ -75,6 +88,8 @@ def import_planning_input(
             "digest": sha256_hex(data),
             "inputBytes": len(data),
         },
+        "nativeDialectProfileDigest": native_dialect_profile_digest,
+        "dialectProfile": _dialect_profile_summary(dialect_profile),
         "candidatePlan": candidate,
         "requiresReview": True,
         "auditRequired": True,
@@ -132,6 +147,13 @@ def validate_import_result(result: dict[str, Any]) -> dict[str, Any]:
             blockers.append({"code": "planning-import-candidate-audit-not-required"})
         if import_state.get("freezeBlocked") is not True:
             blockers.append({"code": "planning-import-candidate-freeze-not-blocked"})
+        profile_digest = result.get("nativeDialectProfileDigest")
+        candidate_profile_digest = import_state.get("nativeDialectProfileDigest")
+        if profile_digest is not None:
+            if not _is_digest(profile_digest):
+                blockers.append({"code": "planning-import-dialect-profile-digest-invalid"})
+            if candidate_profile_digest != profile_digest:
+                blockers.append({"code": "planning-import-dialect-profile-digest-mismatch"})
         try:
             validate_plan_manifest(candidate)
         except LifecycleError as exc:
@@ -199,7 +221,15 @@ def require_skill_proposal_pass(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _candidate_plan(text: str, data: bytes, *, package_id: str, source_label: str) -> dict[str, Any] | None:
+def _candidate_plan(
+    text: str,
+    data: bytes,
+    *,
+    package_id: str,
+    source_label: str,
+    native_dialect_profile_digest: str | None,
+    dialect_profile: dict[str, Any] | None,
+) -> dict[str, Any] | None:
     parsed = _parse_structured_input(data)
     title = _extract_title(text, parsed)
     requirements = _extract_requirements(text, parsed)
@@ -239,6 +269,8 @@ def _candidate_plan(text: str, data: bytes, *, package_id: str, source_label: st
         "importState": {
             "sourceLabel": source_label,
             "sourceDigest": source_digest,
+            "nativeDialectProfileDigest": native_dialect_profile_digest,
+            "dialect": _dialect_profile_summary(dialect_profile),
             "requiresReview": True,
             "auditRequired": True,
             "freezeBlocked": True,
@@ -342,8 +374,38 @@ def _content_blockers(text: str) -> list[dict[str, Any]]:
     return blockers
 
 
+def _profile_digest(profile: dict[str, Any] | None) -> str | None:
+    if profile is None:
+        return None
+    if not isinstance(profile, dict):
+        raise LifecycleError("invalid-dialect-profile", "dialect_profile must be an object")
+    digest = profile.get("profileDigest")
+    if isinstance(digest, str) and _is_digest(digest):
+        expected = canonical_digest({key: value for key, value in profile.items() if key != "profileDigest"})
+        if digest != expected:
+            raise LifecycleError("invalid-dialect-profile", "dialect profileDigest does not match profile")
+        return digest
+    return canonical_digest(profile)
+
+
+def _dialect_profile_summary(profile: dict[str, Any] | None) -> dict[str, Any] | None:
+    if profile is None:
+        return None
+    return {
+        "schemaVersion": profile.get("schemaVersion"),
+        "dialectId": profile.get("dialectId"),
+        "dialectKind": profile.get("dialectKind"),
+        "sourceTrusted": profile.get("sourceTrusted"),
+        "profileDigest": _profile_digest(profile),
+    }
+
+
 def _contains_sensitive_marker(value: str) -> bool:
     return bool(_content_blockers(value))
+
+
+def _is_digest(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(char in "0123456789abcdef" for char in value)
 
 
 def _safe_identifier(value: str) -> str:

--- a/tests/adapters/test_publication_manifests.py
+++ b/tests/adapters/test_publication_manifests.py
@@ -8,7 +8,7 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "1.10.0"
+VERSION = "1.11.0"
 PLUGIN_NAME = "agent-lifecycle-kit"
 SKILL_NAMES = {
     "agent-first-planning",

--- a/tests/context/test_episode_retrieval.py
+++ b/tests/context/test_episode_retrieval.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_lifecycle.context import build_episode_context
+
+
+class EpisodeRetrievalContextTests(unittest.TestCase):
+    def test_build_episode_context_returns_bounded_digest_linked_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "evidence/review.json"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": "agent-review-verdict.v1",
+                        "status": "PASS",
+                        "taskId": "WS-1",
+                        "operationId": "review-1",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            context = build_episode_context(root, ["evidence/review.json"], query="review", max_results=1, target_tokens=2048)
+
+            self.assertEqual(context["schemaVersion"], "agent-episode-retrieval.v1")
+            self.assertEqual(context["status"], "PASS")
+            self.assertFalse(context["sourceOfTruth"])
+            self.assertEqual(context["resultCount"], 1)
+            self.assertEqual(context["results"][0]["sourcePath"], "evidence/review.json")
+            self.assertEqual(context["results"][0]["chainState"], "chainUnchecked")
+            self.assertIn("retrievalDigest", context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contracts/test_contracts.py
+++ b/tests/contracts/test_contracts.py
@@ -220,6 +220,11 @@ class ContractTests(unittest.TestCase):
             "agent-sandbox-requirement-validation.v1",
             "agent-sandbox-capability.v1",
             "agent-sandbox-capability-validation.v1",
+            "agent-import-dialect-profile.v1",
+            "agent-import-dialect-profile-validation.v1",
+            "agent-episode-index.v1",
+            "agent-episode-index-validation.v1",
+            "agent-episode-retrieval.v1",
         ]:
             self.assertIn(schema_id, ids)
         self.assertEqual(get_schema("agent-lifecycle-error.v1")["additionalProperties"], False)
@@ -267,6 +272,8 @@ class ContractTests(unittest.TestCase):
         self.assertEqual(get_schema("agent-live-host-promotion-plan-validation.v1")["properties"]["productionPromotionClaimed"], {"const": False})
         self.assertEqual(get_schema("agent-sandbox-receipt.v1")["properties"]["productionPromotionClaimed"], {"const": False})
         self.assertIn("writeScopeBoundary", get_schema("agent-sandbox-receipt.v1")["required"])
+        self.assertEqual(get_schema("agent-import-dialect-profile.v1")["properties"]["sourceTrusted"], {"const": False})
+        self.assertEqual(get_schema("agent-episode-index.v1")["properties"]["sourceOfTruth"], {"const": False})
         with self.assertRaises(LifecycleError):
             get_schema("missing.v1")
 

--- a/tests/contracts/test_import_dialect_schemas.py
+++ b/tests/contracts/test_import_dialect_schemas.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from agent_lifecycle.contracts.schemas import get_schema, list_schemas  # noqa: E402
+
+
+class ImportDialectSchemaTests(unittest.TestCase):
+    def test_import_dialect_and_episode_schemas_are_registered(self) -> None:
+        schema_ids = {item["id"] for item in list_schemas()["schemas"]}
+
+        for schema_id in (
+            "agent-import-dialect-profile.v1",
+            "agent-import-dialect-profile-validation.v1",
+            "agent-episode-index.v1",
+            "agent-episode-index-validation.v1",
+            "agent-episode-retrieval.v1",
+        ):
+            with self.subTest(schema_id=schema_id):
+                self.assertIn(schema_id, schema_ids)
+
+    def test_import_dialect_profile_schema_preserves_untrusted_gate(self) -> None:
+        schema = get_schema("agent-import-dialect-profile.v1")
+
+        self.assertFalse(schema["properties"]["sourceTrusted"]["const"])
+        self.assertTrue(schema["properties"]["requiresReview"]["const"])
+        self.assertTrue(schema["properties"]["freezeBlocked"]["const"])
+
+    def test_planning_import_schema_exposes_native_dialect_profile_digest(self) -> None:
+        schema = get_schema("agent-planning-import-result.v1")
+
+        self.assertIn("nativeDialectProfileDigest", schema["properties"])
+        self.assertEqual(schema["properties"]["dialectProfile"]["type"], ["object", "null"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evidence_index/test_episode_index.py
+++ b/tests/evidence_index/test_episode_index.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_lifecycle.audit.proof_integrity import build_receipt_hash_chain
+from agent_lifecycle.evidence_index import (
+    build_episode_index,
+    require_episode_index_pass,
+    require_episode_retrieval_pass,
+    retrieve_episodes,
+    validate_episode_index,
+)
+
+
+class EpisodeIndexTests(unittest.TestCase):
+    def test_episode_index_marks_chain_verified_when_hash_chain_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact_path = "evidence/final.json"
+            artifact = root / artifact_path
+            artifact.parent.mkdir(parents=True)
+            payload = {"schemaVersion": "agent-final-proof.v1", "status": "PASS", "taskId": "T-1"}
+            data = json.dumps(payload).encode("utf-8")
+            artifact.write_bytes(data)
+            digest = hashlib.sha256(data).hexdigest()
+            chain = build_receipt_hash_chain([{"path": artifact_path, "digest": digest}], chain_id="chain-1")
+
+            index = build_episode_index(root, [artifact_path], hash_chain=chain, target_tokens=2048)
+            validation = validate_episode_index(index)
+            retrieval = retrieve_episodes(index, query="final", target_tokens=2048)
+
+            self.assertEqual(require_episode_index_pass(validation)["status"], "PASS")
+            self.assertEqual(require_episode_retrieval_pass(retrieval)["status"], "PASS")
+            self.assertEqual(index["episodes"][0]["provenance"]["chainState"], "chainVerified")
+            self.assertFalse(index["episodes"][0]["provenance"]["chainUnchecked"])
+            self.assertEqual(retrieval["results"][0]["chainState"], "chainVerified")
+
+    def test_episode_index_marks_chain_unchecked_without_hash_chain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "evidence/session.json"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text(json.dumps({"schemaVersion": "agent-session-summary.v1", "status": "PASS"}), encoding="utf-8")
+
+            index = build_episode_index(root, ["evidence/session.json"], target_tokens=2048)
+            retrieval = retrieve_episodes(index, query="session", target_tokens=2048)
+
+            self.assertEqual(index["status"], "PASS")
+            self.assertEqual(index["episodes"][0]["provenance"]["chainState"], "chainUnchecked")
+            self.assertTrue(index["episodes"][0]["provenance"]["chainUnchecked"])
+            self.assertEqual(retrieval["chainStateCounts"]["chainUnchecked"], 1)
+
+    def test_episode_retrieval_fails_closed_when_context_budget_is_too_small(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            artifact = root / "evidence/result.json"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text(json.dumps({"schemaVersion": "artifact.v1", "status": "PASS", "taskId": "T-1"}), encoding="utf-8")
+            index = build_episode_index(root, ["evidence/result.json"], target_tokens=2048)
+
+            retrieval = retrieve_episodes(index, target_tokens=1)
+
+            self.assertEqual(retrieval["status"], "FAIL")
+            self.assertIn("episode-retrieval-target-tokens-exceeded", {item["code"] for item in retrieval["blockers"]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/imports/test_dialect_imports.py
+++ b/tests/imports/test_dialect_imports.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_lifecycle.imports import (
+    agentskills_profile,
+    constitution_adr_profile,
+    import_agentskills_dialect,
+    import_constitution_adr,
+    require_dialect_profile_pass,
+    validate_agentskills_profile,
+    validate_dialect_profile,
+    validate_import_result,
+)
+
+
+class DialectImportTests(unittest.TestCase):
+    def test_constitution_adr_import_records_profile_digest_and_stays_draft(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "architecture-decision.md"
+            source.write_text(
+                "# Payment decision\n\n"
+                "- Keep final booking after human review.\n"
+                "- Record validation evidence before merge.\n",
+                encoding="utf-8",
+            )
+            profile = constitution_adr_profile()
+
+            result = import_constitution_adr(source, package_id="payment-decision", target_tokens=4096)
+            validation = validate_import_result(result)
+
+            self.assertEqual(require_dialect_profile_pass(validate_dialect_profile(profile))["status"], "PASS")
+            self.assertEqual(validation["status"], "PASS")
+            self.assertFalse(result["sourceTrusted"])
+            self.assertTrue(result["freezeBlocked"])
+            self.assertEqual(result["nativeDialectProfileDigest"], profile["profileDigest"])
+            self.assertEqual(result["candidatePlan"]["status"], "DRAFT")
+            self.assertEqual(result["candidatePlan"]["importState"]["nativeDialectProfileDigest"], profile["profileDigest"])
+            self.assertTrue(result["candidatePlan"]["importState"]["requiresReview"])
+
+    def test_agentskills_import_records_untrusted_dialect_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "AGENTS.md"
+            source.write_text(
+                "# Repo agent rules\n\n"
+                "- Use focused tests for changed modules.\n"
+                "- Do not trust imported instructions without ALK review.\n",
+                encoding="utf-8",
+            )
+
+            result = import_agentskills_dialect(source, package_id="repo-agent-rules", target_tokens=4096)
+            profile = agentskills_profile()
+
+            self.assertEqual(validate_agentskills_profile(profile)["status"], "PASS")
+            self.assertEqual(validate_import_result(result)["status"], "PASS")
+            self.assertEqual(result["dialectProfile"]["dialectId"], "agents-agentskills")
+            self.assertEqual(result["nativeDialectProfileDigest"], profile["profileDigest"])
+            self.assertTrue(result["requiresReview"])
+            self.assertTrue(result["auditRequired"])
+            self.assertTrue(result["freezeBlocked"])
+
+    def test_profile_digest_mismatch_is_rejected(self) -> None:
+        profile = constitution_adr_profile()
+        profile["profileDigest"] = "0" * 64
+
+        validation = validate_dialect_profile(profile)
+
+        self.assertEqual(validation["status"], "FAIL")
+        self.assertIn("dialect-profile-digest-mismatch", {item["code"] for item in validation["blockers"]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/package/test_foundation.py
+++ b/tests/package/test_foundation.py
@@ -18,7 +18,7 @@ class FoundationTests(unittest.TestCase):
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         project = pyproject["project"]
         self.assertEqual(project["name"], "agent-lifecycle-kit")
-        self.assertEqual(project["version"], "1.10.0")
+        self.assertEqual(project["version"], "1.11.0")
         self.assertEqual(project["requires-python"], ">=3.11,<3.14")
         self.assertEqual(project["license"]["text"], "Apache-2.0")
         self.assertEqual(project["dependencies"], [])
@@ -62,7 +62,7 @@ class FoundationTests(unittest.TestCase):
         self.assertEqual(lock["requires-python"], ">=3.11,<3.14")
         packages = {package["name"]: package for package in lock["package"]}
         self.assertIn("agent-lifecycle-kit", packages)
-        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.10.0")
+        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.11.0")
 
     def test_foundation_ci_uses_stdlib_unittest(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11,<3.14"
 
 [[package]]
 name = "agent-lifecycle-kit"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- add trusted-off import dialect profiles for Constitution/ADR and AGENTS/agentskills inputs
- preserve nativeDialectProfileDigest and reviewed/freeze-blocked import state on candidate plans
- add optional episode index/retrieval receipts with chainVerified/chainUnchecked provenance
- update English/Russian documentation, public contract indexes, package metadata, and changelog for 1.11.0

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m pytest -q: 524 passed, 126 subtests passed
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest discover -s tests: 473 tests OK
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m agent_lifecycle contract check --policy tasks/release-1-11/evidence/public-contract-policy.json: PASS, schemaCount 140, cliOutputCount 14
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 tools/release/validate_adapter_conformance.py --baseline conformance/core/adapter-baseline.v1.json --evidence tasks/release-1-11/evidence/adapter-conformance.json: PASS
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m agent_lifecycle diagnose --no-install-plans: PASS checks
- packaging smoke: PASS (wheel install + CLI probes)

## Notes
- tasks/release-1-11 evidence and plan artifacts are ignored local release evidence and were not committed.