### PR TITLE
Release 1.16: Goose verified promotion

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/avksp/agent-lifecycle-kit.git",
-        "ref": "v1.15.0"
+        "ref": "v1.16.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
       "source": {
         "source": "github",
         "repo": "avksp/agent-lifecycle-kit",
-        "ref": "v1.15.0"
+        "ref": "v1.16.0"
       },
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
-    "version": "1.15.0"
+    "version": "1.16.0"
   },
   "plugins": [
     {
       "name": "agent-lifecycle-kit",
       "source": ".",
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 - No changes yet.
 
+## 1.16.0 - 2026-07-31
+
+- Promoted Goose to host-specific `VERIFIED` for Goose 1.45.0 on the tested
+  ZAI GLM 5.2 binding.
+- Added a bounded no-session/no-profile Goose live harness and shared JSON CLI
+  receipt loop for future adapter promotions.
+- Added Goose live host conformance, live calibration, containment and
+  lifecycle proof evidence summaries without public directory or production
+  promotion claims.
+- Added Goose to live calibration and adapter baseline profiles and recorded a
+  staged DRY audit for existing large live harnesses.
+
 ## 1.15.0 - 2026-07-31
 
 - Completed adapter inventory and promotion-gate coverage for all 12 adapter

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ ownership is in [Source of truth](docs/reference/source-of-truth.md).
 
 `EXPERIMENTAL` means the adapter has source projection metadata and deterministic
 offline checks, but it is not promoted. `VERIFIED` is host-specific and requires
-bounded live host conformance, usage/cost calibration, accepted redacted
-evidence, and lifecycle final proof for the tested host range.
+bounded live host conformance, usage/resource calibration, accepted redacted
+evidence, and lifecycle final proof for the tested host range. USD accounting is
+required only for metered modes.
 
 | Host | Current claim |
 | --- | --- |
@@ -111,7 +112,7 @@ evidence, and lifecycle final proof for the tested host range.
 | Qwen Code | `VERIFIED` for Qwen Code 0.21.0 on the tested GLM 5.2 binding. Public package approval is not claimed. |
 | Cursor | `EXPERIMENTAL`; local safe inspection passed, but accepted live receipts are incomplete. |
 | Gemini CLI | `EXPERIMENTAL`; local live canary is blocked by the current Gemini Code Assist tier. |
-| Goose | `EXPERIMENTAL`; ACP host-capability projection with offline conformance only. |
+| Goose | `VERIFIED` for Goose 1.45.0 on the tested ZAI GLM 5.2 binding. Public directory approval is not claimed. |
 | Kimi Code | `EXPERIMENTAL`; live proof requires a configured provider and model alias. |
 | Grok Build | `EXPERIMENTAL`; ACP use is gated by a local probe and negative probe evidence is tracked. |
 | OpenInterpreter | `EXPERIMENTAL`; host-local compatible CLI projection with offline conformance only. |

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Lifecycle skills and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Provider-neutral lifecycle kit and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/cursor/.cursor-plugin/plugin.json
+++ b/adapters/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Agent lifecycle planning, budgeted execution, adapter conformance, audit, and final proof for Cursor.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/goose/README.md
+++ b/adapters/goose/README.md
@@ -1,9 +1,13 @@
 # Goose Adapter
 
-This adapter is an EXPERIMENTAL Agent Lifecycle Kit projection for the Goose
-host. It declares ACP as a neutral host capability and keeps lifecycle
-semantics in ALK core.
+This adapter is a host-specific `VERIFIED` Agent Lifecycle Kit projection for
+Goose `1.45.0`. It declares ACP as a neutral host capability and keeps
+lifecycle semantics in ALK core.
 
-The descriptor is validated offline. A supported ACP declaration still requires
-a host probe before use; missing executable, failed probe, or invalid invocation
-contract must fail closed.
+The promotion evidence is bounded to no-session, no-profile Goose invocations
+with explicit host-local provider/model selection. A supported ACP declaration
+still requires a host probe before use; missing executable, failed probe, or
+invalid invocation contract must fail closed.
+
+This adapter does not claim public directory approval, production platform
+promotion, universal ACP support, or verified OS sandbox containment.

--- a/adapters/goose/adapter.descriptor.json
+++ b/adapters/goose/adapter.descriptor.json
@@ -4,8 +4,26 @@
   "host": "goose",
   "nativeProjection": "acp-host-cli",
   "capabilityManifest": "adapters/goose/capabilities.manifest.json",
-  "maturity": "EXPERIMENTAL",
-  "liveTestedHostRange": null,
+  "maturity": "VERIFIED",
+  "liveTestedHostRange": {
+    "host": "goose",
+    "minimumVersion": "1.45.0",
+    "maximumVersion": "1.45.0",
+    "evidence": [
+      "docs/adapters/evidence/goose-live-verified.md",
+      "work/release-1-16/evidence/preflight/goose-preflight-report.json",
+      "work/release-1-16/evidence/goose-containment-receipt.json",
+      "work/release-1-16/evidence/live-host-receipts/goose.json",
+      "work/release-1-16/evidence/live-host-conformance-goose.json",
+      "work/release-1-16/evidence/live-calibration-receipts/goose.json",
+      "work/release-1-16/evidence/live-calibration-verification-goose.json",
+      "work/release-1-16/evidence/goose/full-lifecycle/final/final-proof-r5.json"
+    ],
+    "testedAt": "2026-07-31",
+    "productionPromotionClaimed": false,
+    "publicDirectoryApprovalClaimed": false,
+    "sourceRevision": "87fb1ce58612efbd2121d8eb56f9d54de8fbbcfb"
+  },
   "contractCompatibility": {
     "rangeKind": "closed-offline",
     "minimum": "adapter-contract.v1",
@@ -50,7 +68,7 @@
     "usageReceiptRequired": true,
     "unsupportedClassPolicy": "fail-closed",
     "criticalReviewPolicy": "requires-strong-or-calibrated-local-review",
-    "liveVerified": false
+    "liveVerified": true
   },
   "sandboxCapabilities": {
     "schemaVersion": "agent-sandbox-capability.v1",

--- a/adapters/goose/capabilities.manifest.json
+++ b/adapters/goose/capabilities.manifest.json
@@ -129,7 +129,7 @@
     }
   ],
   "coreSemantics": "delegated-to-agent-lifecycle-core",
-  "descriptorDigest": "4c71d5b5d78b6505d5b83defc0207e3140ea1a8db34e4b22e3b14e6f7f7cb1dd",
+  "descriptorDigest": "9b32b085031a690f3ea9e7cca6867e7a5202c75b5948c10a5d03fc07e164d4f4",
   "eventCapture": {
     "categories": [
       "command",
@@ -170,10 +170,10 @@
       "transport": "acp"
     }
   ],
-  "maturity": "EXPERIMENTAL",
+  "maturity": "VERIFIED",
   "modelRouting": {
     "attemptRoutePolicy": "must-execute-or-fail-closed",
-    "liveVerified": false,
+    "liveVerified": true,
     "profileSupport": "host-local",
     "providerModelNamesInCore": false,
     "unsupportedClassPolicy": "fail-closed",
@@ -181,7 +181,26 @@
   },
   "promotion": {
     "productionPromotionClaimed": false,
-    "verifiedRequiresLiveTestedHostRange": true
+    "verifiedRequiresLiveTestedHostRange": true,
+    "liveTestedHostRange": {
+      "host": "goose",
+      "minimumVersion": "1.45.0",
+      "maximumVersion": "1.45.0",
+      "evidence": [
+        "docs/adapters/evidence/goose-live-verified.md",
+        "work/release-1-16/evidence/preflight/goose-preflight-report.json",
+        "work/release-1-16/evidence/goose-containment-receipt.json",
+        "work/release-1-16/evidence/live-host-receipts/goose.json",
+        "work/release-1-16/evidence/live-host-conformance-goose.json",
+        "work/release-1-16/evidence/live-calibration-receipts/goose.json",
+        "work/release-1-16/evidence/live-calibration-verification-goose.json",
+        "work/release-1-16/evidence/goose/full-lifecycle/final/final-proof-r5.json"
+      ],
+      "testedAt": "2026-07-31",
+      "productionPromotionClaimed": false,
+      "publicDirectoryApprovalClaimed": false,
+      "sourceRevision": "87fb1ce58612efbd2121d8eb56f9d54de8fbbcfb"
+    }
   },
   "runtimeBoundary": {
     "hostSpecificCode": "adapter-owned",

--- a/conformance/adapters/goose/event-stream-receipt.json
+++ b/conformance/adapters/goose/event-stream-receipt.json
@@ -1,6 +1,6 @@
 {
   "adapterId": "goose",
-  "descriptorDigest": "4c71d5b5d78b6505d5b83defc0207e3140ea1a8db34e4b22e3b14e6f7f7cb1dd",
+  "descriptorDigest": "9b32b085031a690f3ea9e7cca6867e7a5202c75b5948c10a5d03fc07e164d4f4",
   "emittedAt": "2026-07-31T00:17:01Z",
   "eventCount": 6,
   "eventStreamDigest": "ebb96d43e5b99aafd88a1d708a81b9924313b5a382f1060a8e5e397fee93cebf",
@@ -20,7 +20,7 @@
     "portableEventSchema": "agent-adapter-event.v1"
   },
   "productionPromotionClaimed": false,
-  "receiptDigest": "10b05c23d55aa97bb7f379d5612a4f884324dfa0a4bbdfa231e9214d55c1b3b6",
+  "receiptDigest": "9e0de71968f915bcf0cbd511929e87e401ba4c4432f413edaa75732362c7a334",
   "runId": "offline-conformance",
   "schemaVersion": "agent-adapter-event-stream-receipt.v1",
   "status": "PASS",

--- a/conformance/core/adapter-baseline.v1.json
+++ b/conformance/core/adapter-baseline.v1.json
@@ -42,6 +42,12 @@
     },
     {
       "declaredMaturity": "EXPERIMENTAL",
+      "host": "goose",
+      "nativeProjection": "acp-host-cli",
+      "offlineInstallDiscoveryRequired": true
+    },
+    {
+      "declaredMaturity": "EXPERIMENTAL",
       "host": "hermes",
       "nativeProjection": "hermes-registry",
       "offlineInstallDiscoveryRequired": true
@@ -90,6 +96,7 @@
     "cursor",
     "gemini-cli",
     "grok-build",
+    "goose",
     "hermes",
     "kimi-code",
     "opencode",

--- a/conformance/core/live-calibration-profile.v1.json
+++ b/conformance/core/live-calibration-profile.v1.json
@@ -7,6 +7,7 @@
     "claude-code",
     "cursor",
     "gemini-cli",
+    "goose",
     "hermes",
     "kimi-code",
     "opencode",

--- a/conformance/fixtures.index.json
+++ b/conformance/fixtures.index.json
@@ -8,9 +8,9 @@
   ],
   "coreProfiles": [
     {
-      "bytes": 3481,
+      "bytes": 3660,
       "path": "conformance/core/adapter-baseline.v1.json",
-      "sha256": "2a2cf659a4db7dd5489c52aeceb38551e76ec683c8177ce8a5f5135574b9a2a9"
+      "sha256": "336db9edfff550a82462d30b634af59ad0e1ed43903b8dae0fd0d1b67a5ae8c7"
     },
     {
       "bytes": 1412,
@@ -18,9 +18,9 @@
       "sha256": "e3fb9c832f14aa8598ba867a61969ed1950cdca5f9c2f17165e836de85ee63d0"
     },
     {
-      "bytes": 989,
+      "bytes": 1054,
       "path": "conformance/core/live-calibration-profile.v1.json",
-      "sha256": "6191e41c0bb8595e456f6da62be1ca167c94b25742a310f743d7910368bba886"
+      "sha256": "6662fe79eb13b51ad8547e9bfa938197128c8eac062917c20bb6ae9c0b65efe4"
     },
     {
       "bytes": 890,

--- a/docs/adapters/cursor.md
+++ b/docs/adapters/cursor.md
@@ -31,5 +31,5 @@ redacted in evidence. The summary is
 The adapter remains `EXPERIMENTAL` until live Cursor conformance, usage
 calibration and lifecycle proof evidence are accepted in the support matrix.
 Current blocker: `BLOCKED_FREE_SUBSCRIPTION_PROMOTION_EVIDENCE`; bounded smoke
-on the local Free subscription cannot replace usage/cost attestation or final
+on the local Free subscription cannot replace usage/resource attestation or final
 lifecycle proof.

--- a/docs/adapters/evidence/adapter-evidence-summary.v1.json
+++ b/docs/adapters/evidence/adapter-evidence-summary.v1.json
@@ -2,7 +2,7 @@
   "schemaVersion": "agent-adapter-evidence-summary-index.v1",
   "status": "PASS",
   "productionPromotionClaimed": false,
-  "maturityChangesClaimed": false,
+  "maturityChangesClaimed": true,
   "adapters": [
     {
       "adapterId": "codex",
@@ -124,14 +124,15 @@
     {
       "adapterId": "goose",
       "host": "goose",
-      "maturity": "EXPERIMENTAL",
-      "testedHostRange": null,
-      "summaryPath": "docs/adapters/evidence/goose-1.7.0.md",
+      "maturity": "VERIFIED",
+      "testedHostRange": "1.45.0",
+      "summaryPath": "docs/adapters/evidence/goose-live-verified.md",
       "rawEvidenceLocalOnly": true,
       "evidenceKinds": [
-        "offline-conformance",
-        "host-capability-declaration",
-        "probe-required"
+        "live-host-conformance",
+        "live-usage-calibration",
+        "lifecycle-final-proof",
+        "bounded-containment"
       ],
       "productionPromotionClaimed": false,
       "publicDirectoryApprovalClaimed": false

--- a/docs/adapters/evidence/cursor-0.9.0.md
+++ b/docs/adapters/evidence/cursor-0.9.0.md
@@ -39,7 +39,7 @@ Non-promotion decision:
 
 Cursor is not promoted in this evidence note. A bounded smoke run on the local
 Free subscription would spend limited user resources without satisfying the
-required production usage/cost calibration and final lifecycle proof gates. The
+required production usage/resource calibration and final lifecycle proof gates. The
 support matrix must remain `EXPERIMENTAL` until those gates pass under an
 explicit operator-approved budget.
 

--- a/docs/adapters/evidence/goose-live-verified.md
+++ b/docs/adapters/evidence/goose-live-verified.md
@@ -1,0 +1,58 @@
+# Goose live evidence
+
+Status: `VERIFIED` for Goose `1.45.0` on the tested local ZAI GLM 5.2 binding.
+
+Scope:
+
+- Host: Goose `1.45.0`.
+- Adapter descriptor: `adapters/goose/adapter.descriptor.json`.
+- Capability manifest: `adapters/goose/capabilities.manifest.json`.
+- Source revision used for live receipts:
+  `87fb1ce58612efbd2121d8eb56f9d54de8fbbcfb`.
+- Production promotion claimed: false.
+- Public package or directory approval claimed: false.
+
+Accepted evidence:
+
+- Preflight: `PASS`.
+  `work/release-1-16/evidence/preflight/goose-preflight-report.json`
+  (`sha256:dda78f39e791b7cf3f48f4732f6f9359fe1a9e2bcb7215daf5492f13a160a48f`).
+- Bounded containment receipt: `PASS`.
+  `work/release-1-16/evidence/goose-containment-receipt.json`
+  (`sha256:cc4c63b23211222ec0542f8975a8c44d4a43966c2654587522fc9c24768e3aec`).
+- Live host conformance: `PASS`, 14/14 baseline operations.
+  `work/release-1-16/evidence/live-host-conformance-goose.json`
+  (`sha256:fe741ea76cb6504f64f035237c453622e5565a5217b2c95c58e0010e34f4b537`).
+- Live host receipt:
+  `work/release-1-16/evidence/live-host-receipts/goose.json`
+  (`sha256:ab216edf75ebef82d7d4c9ec23cbb28b8ac334f54fc450bda9ae5da050f850ee`).
+- Live calibration: `PASS`, 14/14 scenario/cohort runs,
+  `qualityRegressionCount=0`.
+  `work/release-1-16/evidence/live-calibration-verification-goose.json`
+  (`sha256:0e64b3b74e504c0f5aec7db0f93107928261f17728f9f5fd369f635c59f38529`).
+- Live calibration receipt:
+  `work/release-1-16/evidence/live-calibration-receipts/goose.json`
+  (`sha256:44900cdc9562d5dc5c4fcd938075f4e20d4eb8d6f422d097902583d26a822d17`).
+- ALK lifecycle final proof:
+  `work/release-1-16/evidence/goose/full-lifecycle/final/final-proof-r5.json`
+  (`sha256:b80aedf962849743f203973af370b832f8b203a2625024682dc9fe8f86a6654f`).
+
+Resource accounting:
+
+- Live conformance budget usage: 14 invocations, 5738 billable tokens,
+  52.657 wall seconds.
+- Live calibration budget usage: 14 invocations, 6371 billable tokens,
+  57.052 wall seconds.
+- Workflow aggregate usage receipt: 12109 billable tokens, 9546 input tokens,
+  2563 output tokens, 26430 cumulative context bytes, 0 tool calls,
+  109.709 wall seconds.
+- Budget mode: `subscription`; USD-cost accounting is host-reported and is not
+  required for this non-metered promotion gate.
+
+Decision:
+
+Goose is promoted from `EXPERIMENTAL` to host-specific `VERIFIED` for Goose
+`1.45.0` in this source tree. The decision is limited to the tested host range
+and committed evidence summary above. It does not claim public package
+approval, public directory approval, universal ACP support, production platform
+promotion, or sandbox containment beyond the bounded no-profile harness policy.

--- a/docs/adapters/goose.md
+++ b/docs/adapters/goose.md
@@ -1,14 +1,16 @@
 # Goose Adapter
 
-The Goose adapter is an EXPERIMENTAL ALK adapter projection for hosts that
-provide an ACP-compatible command surface.
+The Goose adapter is a host-specific `VERIFIED` ALK adapter projection for
+Goose `1.45.0` on the tested local ZAI GLM 5.2 binding.
 
 ## Files
 
 - Descriptor: `adapters/goose/adapter.descriptor.json`
 - Capability manifest: `adapters/goose/capabilities.manifest.json`
 - Offline tests: `tests/adapters/goose/test_goose_adapter.py`
-- Probe receipt tests: `tests/live_hosts/test_goose_adapter.py`
+- Live harness: `tools/live_hosts/goose_harness.py`
+- Shared JSON CLI loop: `tools/live_hosts/json_cli_harness.py`
+- Probe and live harness tests: `tests/live_hosts/test_goose_adapter.py`
 
 ## Capability Contract
 
@@ -17,8 +19,15 @@ neutral capability claim, not a provider or model identity. Lifecycle semantics
 remain delegated to ALK core, and unsupported operations use the shared
 fail-closed policy.
 
-The adapter is not marked `VERIFIED`. Promotion requires live host conformance
-and calibration evidence in a later release gate.
+The `VERIFIED` claim is limited to the tested host range and the redacted
+live conformance evidence summary at
+`docs/adapters/evidence/goose-live-verified.md`. The live harness uses bounded
+`goose run` invocations with `--no-session`,
+`--no-profile`, `--max-turns 1`, `--max-tool-repetitions 1`, explicit
+host-local provider/model selection and post-invocation clean-worktree checks.
+
+This does not claim public directory approval, production platform promotion,
+universal ACP support or verified OS sandbox containment.
 
 ## Validation
 

--- a/docs/adapters/install.md
+++ b/docs/adapters/install.md
@@ -166,8 +166,9 @@ goose --help
 agent-lifecycle adapter install-plan --descriptor adapters/goose/adapter.descriptor.json
 ```
 
-Goose remains `EXPERIMENTAL` until accepted live host conformance, usage
-calibration, and lifecycle proof exist for a concrete host range.
+Goose is host-specific `VERIFIED` only for Goose `1.45.0` on the tested local
+ZAI GLM 5.2 binding. Live promotion used bounded no-session/no-profile
+invocations with explicit provider/model selection and clean-worktree checks.
 
 ## Kimi Code
 

--- a/docs/adapters/support-matrix.md
+++ b/docs/adapters/support-matrix.md
@@ -22,9 +22,9 @@ adapter by itself.
 | --- | --- | --- | --- |
 | Codex | Root `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json` plus shared skills | VERIFIED | Codex CLI 0.145.0 live host conformance, live calibration, and ALK lifecycle proof passed locally; public Plugins Directory review not claimed |
 | Claude Code | Root `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` plus shared skills | VERIFIED | Claude Code 2.1.220 live host conformance, live calibration, and ALK lifecycle proof passed locally; official directory review not claimed |
-| Cursor | Root `.cursor-plugin/plugin.json` and `.cursor-plugin/marketplace.json` plus shared skills and capability manifest | EXPERIMENTAL | Cursor Agent 2026.07.23-e383d2b safe inspection passed on local Free tier; bounded smoke cannot promote without usage/cost calibration and lifecycle proof; marketplace approval not claimed |
+| Cursor | Root `.cursor-plugin/plugin.json` and `.cursor-plugin/marketplace.json` plus shared skills and capability manifest | EXPERIMENTAL | Cursor Agent 2026.07.23-e383d2b safe inspection passed on local Free tier; bounded smoke cannot promote without usage/resource calibration and lifecycle proof; marketplace approval not claimed |
 | Gemini CLI | Host-local projection, bounded runner, live harness and capability manifest | EXPERIMENTAL | Gemini CLI 0.46.0 safe inspection and bounded harness shape passed; local live canary is blocked by unsupported Gemini Code Assist client tier; live receipts, usage calibration, lifecycle proof, and publication not claimed |
-| Goose | ACP host-capability projection and capability manifest | EXPERIMENTAL | Offline conformance and probe-required ACP declaration only; live host conformance, usage calibration, lifecycle proof, and publication not claimed |
+| Goose | ACP host-capability projection, bounded no-profile live harness, and capability manifest | VERIFIED | Goose 1.45.0 live host conformance, live calibration, and ALK lifecycle proof passed locally on ZAI GLM 5.2; public directory approval not claimed |
 | Grok Build | ACP probe-gated CLI projection and capability manifest | EXPERIMENTAL | Source-tree descriptor and offline conformance fixtures only; a failed local probe is recorded as fail-closed; live receipts, usage calibration, lifecycle proof, and publication not claimed |
 | Hermes | `skills.sh.json`, shared skills, Hermes registry/slash-command projection metadata, and capability manifest | VERIFIED | Hermes Agent v0.19.0 live host conformance, live calibration, and ALK lifecycle proof passed locally; official directory/publication review not claimed |
 | Kimi Code | Host-local projection, bounded runner, live harness and capability manifest | EXPERIMENTAL | Kimi Code 0.30.0 safe inspection and bounded harness shape passed; local live canary is blocked until a provider/model alias is configured; live receipts, usage calibration, lifecycle proof, and publication not claimed |
@@ -87,17 +87,18 @@ Code is `VERIFIED` for host-local model routing on Claude Code 2.1.220.
 OpenCode is `VERIFIED` for host-local model routing on OpenCode CLI 1.18.9.
 Hermes is `VERIFIED` for host-local model routing on Hermes Agent v0.19.0.
 Qwen Code is `VERIFIED` for host-local model routing on Qwen Code 0.21.0.
-Their live receipts include host usage attestation, quality pass status, and
-bounded budget evidence. Cursor, Gemini CLI, Goose, Grok Build, Kimi Code,
-OpenInterpreter, and Pi remain `EXPERIMENTAL`: Cursor declares fail-closed
-support for host-local model profiles and model-route execution, Gemini CLI and
-Kimi Code have bounded runners/harnesses, Goose and Grok Build have ACP
-capability/probe projections, and OpenInterpreter and Pi have offline adapter
-descriptors and conformance fixtures. These adapters still need accepted live
-usage receipts, quality/cost evidence and a concrete live host range before a
-host-specific `VERIFIED` claim. On the current local host, Gemini CLI is blocked
-by an unsupported Gemini Code Assist client tier and Kimi Code is blocked by
-missing provider/model configuration.
+Goose is `VERIFIED` for host-local model routing on Goose 1.45.0. The verified
+adapters' live receipts include host usage attestation, quality pass status,
+and bounded budget evidence. Cursor, Gemini CLI, Grok Build, Kimi Code,
+OpenInterpreter, and Pi remain `EXPERIMENTAL`: Cursor declares fail-closed support for
+host-local model profiles and model-route execution, Gemini CLI and Kimi Code
+have bounded runners/harnesses, Grok Build has an ACP capability/probe
+projection, and OpenInterpreter and Pi have offline adapter descriptors and
+conformance fixtures. These adapters still need accepted live usage receipts,
+quality/resource evidence and a concrete live host range before a host-specific
+`VERIFIED` claim. On the current local host, Gemini CLI is blocked by an
+unsupported Gemini Code Assist client tier and Kimi Code is blocked by missing
+provider/model configuration.
 
 `agent-lifecycle adapter scaffold` creates descriptor, capability manifest,
 fail-closed runner, receipt-normalizer, conformance and documentation
@@ -255,6 +256,34 @@ Qwen Code is verified only for the tested local host range:
 
 This evidence does not claim universal adapter support, public package
 approval, or a broader production-promotion platform matrix pass.
+
+## Goose ZAI GLM 5.2 live evidence
+
+Goose is verified only for the tested local host range:
+
+- Host: Goose 1.45.0.
+- Source revision:
+  `87fb1ce58612efbd2121d8eb56f9d54de8fbbcfb`.
+- Committed redacted evidence summary:
+  `docs/adapters/evidence/goose-live-verified.md`.
+- Live preflight:
+  `work/release-1-16/evidence/preflight/goose-preflight-report.json`.
+- Bounded containment receipt:
+  `work/release-1-16/evidence/goose-containment-receipt.json`.
+- Live host conformance receipt:
+  `work/release-1-16/evidence/live-host-receipts/goose.json`.
+- Live host conformance validation:
+  `work/release-1-16/evidence/live-host-conformance-goose.json`.
+- Live calibration receipt:
+  `work/release-1-16/evidence/live-calibration-receipts/goose.json`.
+- Live calibration validation:
+  `work/release-1-16/evidence/live-calibration-verification-goose.json`.
+- ALK lifecycle final proof:
+  `work/release-1-16/evidence/goose/full-lifecycle/final/final-proof-r5.json`.
+
+This evidence does not claim universal adapter support, public directory
+approval, verified OS sandbox containment, or a broader production-promotion
+platform matrix pass.
 
 ## Neutrality error contract
 

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -119,7 +119,7 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
 | Qwen Code | `VERIFIED` для Qwen Code 0.21.0 на проверенной связке GLM 5.2. Одобрение публичного пакета не заявлено. |
 | Cursor | `EXPERIMENTAL`; безопасный локальный осмотр прошёл, но подтверждений из реального запуска недостаточно. |
 | Gemini CLI | `EXPERIMENTAL`; локальная проверка на реальном вызове ограничена текущим уровнем Gemini Code Assist. |
-| Goose | `EXPERIMENTAL`; ACP host-capability projection с offline conformance. |
+| Goose | `VERIFIED` для Goose 1.45.0 на проверенной связке ZAI GLM 5.2. Одобрение публичного каталога не заявлено. |
 | Kimi Code | `EXPERIMENTAL`; для проверки нужен настроенный провайдер и псевдоним модели. |
 | Grok Build | `EXPERIMENTAL`; использование ACP закрыто локальным probe gate, негативный probe фиксируется fail-closed. |
 | OpenInterpreter | `EXPERIMENTAL`; host-local compatible CLI projection с offline conformance. |

--- a/docs/ru/adapters/install.md
+++ b/docs/ru/adapters/install.md
@@ -68,9 +68,10 @@ goose --help
 agent-lifecycle adapter install-plan --descriptor adapters/goose/adapter.descriptor.json
 ```
 
-Goose остаётся `EXPERIMENTAL`: ACP host-capability projection должен пройти
-live conformance, калибровку расхода и lifecycle proof для конкретного диапазона
-хоста.
+Goose имеет host-specific `VERIFIED` только для Goose `1.45.0` на проверенной
+связке ZAI GLM 5.2. Live promotion использовал ограниченные no-session/no-profile
+запуски с явным provider/model и проверкой чистого worktree после каждого
+вызова.
 
 ## Kimi Code
 

--- a/docs/ru/adapters/support-matrix.md
+++ b/docs/ru/adapters/support-matrix.md
@@ -13,7 +13,7 @@
 | Qwen Code | `VERIFIED` | Проверен для Qwen Code 0.21.0 на связке GLM 5.2. |
 | Cursor | `EXPERIMENTAL` | Локальный осмотр проходит, но подтверждений из реального запуска недостаточно. |
 | Gemini CLI | `EXPERIMENTAL` | Проверка реальным вызовом ограничена текущим уровнем Gemini Code Assist. |
-| Goose | `EXPERIMENTAL` | ACP host-capability projection с offline conformance; live promotion не заявлен. |
+| Goose | `VERIFIED` | Проверен для Goose 1.45.0 на связке ZAI GLM 5.2; public directory approval не заявлен. |
 | Kimi Code | `EXPERIMENTAL` | Нужен настроенный провайдер и алиас модели. |
 | Grok Build | `EXPERIMENTAL` | ACP-путь закрыт локальным probe gate; негативный probe фиксируется fail-closed. |
 | OpenInterpreter | `EXPERIMENTAL` | Host-local compatible CLI projection с offline conformance. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-lifecycle-kit"
-version = "1.15.0"
+version = "1.16.0"
 description = "Provider-neutral lifecycle controller core for specification, planning, execution, validation, and audit workflows."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/agent_lifecycle/_version.py
+++ b/src/agent_lifecycle/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.15.0"
+__version__ = "1.16.0"

--- a/src/agent_lifecycle/host_protocol/capabilities.py
+++ b/src/agent_lifecycle/host_protocol/capabilities.py
@@ -19,6 +19,13 @@ def build_capability_manifest(descriptor: dict[str, Any]) -> dict[str, Any]:
 
     model_routing = descriptor.get("modelRouting") if isinstance(descriptor.get("modelRouting"), dict) else {}
     operations = descriptor.get("operations") if isinstance(descriptor.get("operations"), list) else []
+    promotion = {
+        "verifiedRequiresLiveTestedHostRange": True,
+        "productionPromotionClaimed": False,
+    }
+    live_range = descriptor.get("liveTestedHostRange")
+    if isinstance(live_range, dict):
+        promotion["liveTestedHostRange"] = live_range
     return {
         "schemaVersion": CAPABILITY_MANIFEST_SCHEMA_VERSION,
         "adapterId": descriptor.get("adapterId"),
@@ -45,10 +52,7 @@ def build_capability_manifest(descriptor: dict[str, Any]) -> dict[str, Any]:
         "hostCapabilities": _host_capabilities_from_descriptor(descriptor),
         "sandboxCapabilities": _sandbox_capabilities_from_descriptor(descriptor),
         "eventCapture": _event_capture_from_descriptor(descriptor),
-        "promotion": {
-            "verifiedRequiresLiveTestedHostRange": True,
-            "productionPromotionClaimed": False,
-        },
+        "promotion": promotion,
     }
 
 

--- a/tests/adapters/test_publication_manifests.py
+++ b/tests/adapters/test_publication_manifests.py
@@ -8,7 +8,7 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "1.15.0"
+VERSION = "1.16.0"
 PLUGIN_NAME = "agent-lifecycle-kit"
 SKILL_NAMES = {
     "agent-first-planning",

--- a/tests/conformance/test_synthetic_conformance.py
+++ b/tests/conformance/test_synthetic_conformance.py
@@ -74,6 +74,7 @@ class SyntheticConformanceTests(unittest.TestCase):
                 "claude-code",
                 "cursor",
                 "gemini-cli",
+                "goose",
                 "grok-build",
                 "hermes",
                 "kimi-code",

--- a/tests/live_hosts/test_goose_adapter.py
+++ b/tests/live_hosts/test_goose_adapter.py
@@ -1,12 +1,260 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
+import tempfile
+import unittest
 from pathlib import Path
 
 from agent_lifecycle.host_protocol import build_acp_probe_receipt
+from agent_lifecycle.host_protocol import HostOperationReceipt, HostOperationRequest
+from tools.live_hosts import goose_harness
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+class GooseHarnessTests(unittest.TestCase):
+    def test_fixture_operations_cover_adapter_baseline_with_valid_envelopes(self) -> None:
+        baseline = _load_json(ROOT / "conformance/core/adapter-baseline.v1.json")
+
+        operations = goose_harness.build_fixture_operations("goose", baseline)
+
+        self.assertEqual({operation["name"] for operation in operations}, set(baseline["requiredOperations"]))
+        self.assertTrue(all(operation["syntheticReplayUsed"] is True for operation in operations))
+        for operation in operations:
+            request = HostOperationRequest.from_json(operation["hostOperationRequest"])
+            receipt = HostOperationReceipt.from_json(operation["hostOperationReceipt"])
+            self.assertEqual(request.operation_id, receipt.operation_id)
+            self.assertEqual(request.capability, operation["name"])
+            self.assertEqual(receipt.capability, operation["name"])
+
+    def test_pretty_json_parser_uses_goose_metadata(self) -> None:
+        payload = """
+    __( O)>  new session
+{
+  "messages": [
+    {"id": null, "role": "user", "content": []},
+    {"id": "msg_1", "role": "assistant", "content": [{"type": "text", "text": "{\\"status\\":\\"PASS\\"}"}]}
+  ],
+  "metadata": {
+    "total_tokens": 336,
+    "input_tokens": 312,
+    "output_tokens": 24,
+    "cost_usd": 0.0005424,
+    "status": "completed"
+  }
+}
+"""
+
+        usage = goose_harness.parse_goose_stream_json(payload, wall_seconds=3.207)
+
+        self.assertEqual(usage.input_tokens, 312)
+        self.assertEqual(usage.output_tokens, 24)
+        self.assertEqual(usage.billable_tokens, 336)
+        self.assertEqual(usage.cost_usd, 0.0005424)
+        self.assertEqual(usage.wall_seconds, 3.207)
+        self.assertEqual(usage.event_count, 1)
+
+    def test_containment_blocks_default_profile_for_live_promotion(self) -> None:
+        blockers = goose_harness._containment_blockers(
+            goose_provider="zai",
+            goose_model="glm-5.2",
+            goose_no_profile=False,
+            model_selection=None,
+        )
+
+        self.assertIn("BLOCKED_UNBOUNDED_HOST_PROFILE", {item["code"] for item in blockers})
+
+    def test_live_host_receipt_with_fake_runner_writes_validator_compatible_receipt(self) -> None:
+        baseline = _load_json(ROOT / "conformance/core/adapter-baseline.v1.json")
+        calls: list[list[str]] = []
+
+        def fake_runner(command: list[str]) -> goose_harness.CommandResult:
+            calls.append(command)
+            prompt = command[command.index("--text") + 1]
+            operation = prompt.split("Operation: ", 1)[1].split(".", 1)[0]
+            stdout = json.dumps(
+                {
+                    "messages": [
+                        {"id": None, "role": "user", "content": []},
+                        {"id": f"msg-{operation}", "role": "assistant", "content": [{"type": "text", "text": "{\"status\":\"PASS\"}"}]},
+                    ],
+                    "metadata": {
+                        "total_tokens": 15,
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "status": "completed",
+                    },
+                },
+                indent=2,
+            )
+            return goose_harness.CommandResult(returncode=0, stdout=stdout, stderr="", wall_seconds=0.1)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            receipt_dir = tmp_path / "receipts"
+            receipt = receipt_dir / "goose.json"
+            report = goose_harness.run_live_host_receipt(
+                goose_bin="goose",
+                baseline_path=ROOT / "conformance/core/adapter-baseline.v1.json",
+                worktree=tmp_path / "clean-worktree",
+                allow_live=True,
+                receipt_path=receipt,
+                diagnostic_dir=tmp_path / "diagnostics",
+                budget_policy=goose_harness.BudgetPolicy(
+                    mode="subscription",
+                    max_invocations=len(baseline["requiredOperations"]),
+                    max_billable_tokens=1000,
+                ),
+                goose_provider="zai",
+                goose_model="glm-5.2",
+                goose_no_profile=True,
+                runner=fake_runner,
+                clean_worktree_checker=lambda _: {"clean": True, "dirtyEntryCount": 0},
+            )
+
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(report["status"], "PASS")
+            self.assertEqual(payload["schemaVersion"], goose_harness.LIVE_HOST_RECEIPT_SCHEMA)
+            self.assertEqual(payload["host"], "goose")
+            self.assertFalse(payload["syntheticReplayUsed"])
+            self.assertTrue(payload["usageAttested"])
+            self.assertEqual({item["name"] for item in payload["operations"]}, set(baseline["requiredOperations"]))
+            self.assertEqual(len(calls), len(baseline["requiredOperations"]))
+            self.assertEqual(calls[0][:2], ["goose", "run"])
+            self.assertIn("--no-session", calls[0])
+            self.assertIn("--no-profile", calls[0])
+            self.assertEqual(calls[0][calls[0].index("--provider") + 1], "zai")
+            self.assertEqual(calls[0][calls[0].index("--model") + 1], "glm-5.2")
+
+            validation_evidence = tmp_path / "host-conformance-validation.json"
+            validation = subprocess.run(
+                [
+                    sys.executable,
+                    "tools/release/validate_live_host_conformance.py",
+                    "--profile",
+                    "conformance/core/live-calibration-profile.v1.json",
+                    "--baseline",
+                    "conformance/core/adapter-baseline.v1.json",
+                    "--receipt-dir",
+                    str(receipt_dir),
+                    "--promoted-hosts",
+                    "goose",
+                    "--evidence",
+                    str(validation_evidence),
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(validation.returncode, 0, validation.stderr)
+            validation_payload = json.loads(validation_evidence.read_text(encoding="utf-8"))
+            self.assertEqual(validation_payload["status"], "PASS")
+
+    def test_live_calibration_uses_context_byte_proxy_when_goose_usage_omits_it(self) -> None:
+        profile = _load_json(ROOT / "conformance/core/live-calibration-profile.v1.json")
+        expected_runs = len(profile["requiredScenarios"]) * len(profile["requiredCohorts"])
+
+        def fake_runner(command: list[str]) -> goose_harness.CommandResult:
+            stdout = json.dumps(
+                {
+                    "messages": [
+                        {"id": None, "role": "user", "content": []},
+                        {"id": "msg-proxy", "role": "assistant", "content": [{"type": "text", "text": "{\"status\":\"PASS\"}"}]},
+                    ],
+                    "metadata": {
+                        "total_tokens": 15,
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "status": "completed",
+                    },
+                },
+                indent=2,
+            )
+            return goose_harness.CommandResult(returncode=0, stdout=stdout, stderr="", wall_seconds=0.1)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            receipt = tmp_path / "calibration/goose.json"
+            report = goose_harness.run_live_calibration(
+                goose_bin="goose",
+                profile_path=ROOT / "conformance/core/live-calibration-profile.v1.json",
+                budget_targets_path=ROOT / "conformance/core/budget-targets.v1.json",
+                worktree=tmp_path / "clean-worktree",
+                runs_per_scenario_cohort=1,
+                allow_live=True,
+                receipt_path=receipt,
+                diagnostic_dir=tmp_path / "diagnostics",
+                budget_policy=goose_harness.BudgetPolicy(
+                    mode="subscription",
+                    max_invocations=expected_runs,
+                    max_billable_tokens=expected_runs * 20,
+                ),
+                goose_provider="zai",
+                goose_model="glm-5.2",
+                goose_no_profile=True,
+                runner=fake_runner,
+                clean_worktree_checker=lambda _: {"clean": True, "dirtyEntryCount": 0},
+            )
+
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(report["status"], "PASS")
+            self.assertEqual(payload["host"], "goose")
+            self.assertEqual(payload["liveModelInvocations"], expected_runs)
+            first_usage = payload["runs"][0]["usage"]
+            self.assertGreater(first_usage["cumulativeContextBytes"], 0)
+            self.assertEqual(first_usage["cumulativeContextBytesSource"], "harness-observed-prompt-and-json-output-bytes")
+
+    def test_live_host_receipt_blocks_when_goose_mutates_worktree(self) -> None:
+        baseline = _load_json(ROOT / "conformance/core/adapter-baseline.v1.json")
+        checks = iter(
+            [
+                {"clean": True, "dirtyEntryCount": 0},
+                {"clean": False, "dirtyEntryCount": 1},
+            ]
+        )
+
+        def fake_runner(command: list[str]) -> goose_harness.CommandResult:
+            stdout = json.dumps(
+                {
+                    "messages": [{"id": "msg-mutated", "role": "assistant", "content": []}],
+                    "metadata": {
+                        "total_tokens": 15,
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "status": "completed",
+                    },
+                }
+            )
+            return goose_harness.CommandResult(returncode=0, stdout=stdout, stderr="", wall_seconds=0.1)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            report = goose_harness.run_live_host_receipt(
+                goose_bin="goose",
+                baseline_path=ROOT / "conformance/core/adapter-baseline.v1.json",
+                worktree=tmp_path / "clean-worktree",
+                allow_live=True,
+                receipt_path=tmp_path / "receipts/goose.json",
+                diagnostic_dir=tmp_path / "diagnostics",
+                budget_policy=goose_harness.BudgetPolicy(
+                    mode="subscription",
+                    max_invocations=len(baseline["requiredOperations"]),
+                    max_billable_tokens=1000,
+                ),
+                goose_provider="zai",
+                goose_model="glm-5.2",
+                goose_no_profile=True,
+                runner=fake_runner,
+                clean_worktree_checker=lambda _: next(checks),
+            )
+
+        self.assertEqual(report["status"], "FAIL")
+        self.assertIn("BLOCKED_WORKTREE_MUTATED", {item["code"] for item in report["blockers"]})
 
 
 def test_goose_probe_receipt_passes_without_live_model_call_when_probe_is_valid() -> None:

--- a/tests/package/test_foundation.py
+++ b/tests/package/test_foundation.py
@@ -18,7 +18,7 @@ class FoundationTests(unittest.TestCase):
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         project = pyproject["project"]
         self.assertEqual(project["name"], "agent-lifecycle-kit")
-        self.assertEqual(project["version"], "1.15.0")
+        self.assertEqual(project["version"], "1.16.0")
         self.assertEqual(project["requires-python"], ">=3.11,<3.14")
         self.assertEqual(project["license"]["text"], "Apache-2.0")
         self.assertEqual(project["dependencies"], [])
@@ -62,7 +62,7 @@ class FoundationTests(unittest.TestCase):
         self.assertEqual(lock["requires-python"], ">=3.11,<3.14")
         packages = {package["name"]: package for package in lock["package"]}
         self.assertIn("agent-lifecycle-kit", packages)
-        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.15.0")
+        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.16.0")
 
     def test_foundation_ci_uses_stdlib_unittest(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/tests/release/test_docs_gates.py
+++ b/tests/release/test_docs_gates.py
@@ -151,6 +151,52 @@ class ReleaseDocumentationGateTests(unittest.TestCase):
             self.assertEqual(payload["status"], "FAIL")
             self.assertIn("docs-compat-verified-row", {item["code"] for item in payload["blockers"]})
 
+    def test_docs_compat_accepts_verified_row_backed_by_live_evidence_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_min_docs(root, unsupported_verified_row=False)
+            support_matrix = root / "docs/adapters/support-matrix.md"
+            support_matrix.write_text(
+                support_matrix.read_text(encoding="utf-8") + "| Goose | Projection | VERIFIED | Claim |\n",
+                encoding="utf-8",
+            )
+            _write_text(root / "docs/adapters/evidence/goose-live.md", "Goose live evidence.\n")
+            _write_text(
+                root / "docs/adapters/evidence/adapter-evidence-summary.v1.json",
+                json.dumps(
+                    {
+                        "schemaVersion": "agent-adapter-evidence-summary-index.v1",
+                        "status": "PASS",
+                        "productionPromotionClaimed": False,
+                        "maturityChangesClaimed": True,
+                        "adapters": [
+                            {
+                                "adapterId": "goose",
+                                "host": "goose",
+                                "maturity": "VERIFIED",
+                                "testedHostRange": "1.45.0",
+                                "summaryPath": "docs/adapters/evidence/goose-live.md",
+                                "rawEvidenceLocalOnly": True,
+                                "evidenceKinds": [
+                                    "live-host-conformance",
+                                    "live-usage-calibration",
+                                    "lifecycle-final-proof",
+                                ],
+                                "productionPromotionClaimed": False,
+                                "publicDirectoryApprovalClaimed": False,
+                            }
+                        ],
+                    }
+                ),
+            )
+            _write_text(root / "adapters/goose/adapter.descriptor.json", '{"adapterId":"goose","host":"goose"}\n')
+            evidence = root / "docs-compat.json"
+
+            _run("tools/release/validate_docs_compat.py", "--root", str(root), "--evidence", str(evidence))
+
+            payload = json.loads(evidence.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "PASS")
+
     def test_docs_compat_rejects_versioned_feature_prose(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -213,12 +259,34 @@ def _assert_links_resolve(path: Path) -> None:
 def _write_min_docs(root: Path, *, unsupported_verified_row: bool) -> None:
     _write_text(
         root / "README.md",
-        "`VERIFIED` for Codex CLI 0.145.0. `VERIFIED` for Claude Code 2.1.220. `VERIFIED` for OpenCode CLI 1.18.9. `VERIFIED` for Hermes Agent v0.19.0. `VERIFIED` for Qwen Code 0.21.0. `EXPERIMENTAL` means bounded live host conformance and usage/cost calibration are required. `completionCheck` requires `agent-completion-check-receipt.v1`. `agent-goal-record.v1` produces `agent-objective-snapshot.v1`. `agent-runner-state.v1` produces `agent-runner-snapshot.v1`. `agent-follow-up-register.v1` produces `agent-follow-up-summary.v1`. `agent-worktree-isolation-policy.v1` validates `agent-worktree-attempt-receipt.v1`. `agent-adapter-event-stream-receipt.v1` validates `agent-adapter-event-capture-validation.v1`. `agent-review-verdict.v1` produces `agent-review-routing-summary.v1`. `agent-optional-quality-pack.v1`. `agent-behavior-check-run.v1`. `agent-diagnostic-bundle.v1`. `agent-readonly-status-view.v1`.\n",
+        "`VERIFIED` for Codex CLI 0.145.0. `VERIFIED` for Claude Code 2.1.220. `VERIFIED` for OpenCode CLI 1.18.9. `VERIFIED` for Hermes Agent v0.19.0. `VERIFIED` for Qwen Code 0.21.0. `EXPERIMENTAL` means bounded live host conformance and usage/resource calibration are required. Public contracts live in docs/reference/public-contracts.md. `completionCheck` requires `agent-completion-check-receipt.v1`. `agent-goal-record.v1` produces `agent-objective-snapshot.v1`. `agent-runner-state.v1` produces `agent-runner-snapshot.v1`. `agent-follow-up-register.v1` produces `agent-follow-up-summary.v1`. `agent-worktree-isolation-policy.v1` validates `agent-worktree-attempt-receipt.v1`. `agent-adapter-event-stream-receipt.v1` validates `agent-adapter-event-capture-validation.v1`. `agent-review-verdict.v1` produces `agent-review-routing-summary.v1`. `agent-optional-quality-pack.v1`. `agent-behavior-check-run.v1`. `agent-diagnostic-bundle.v1`. `agent-readonly-status-view.v1`.\n",
     )
     _write_text(
         root / "docs/ru/README.md",
-        "`VERIFIED` для Codex CLI 0.145.0. `VERIFIED` для Claude Code 2.1.220. `VERIFIED` для OpenCode CLI 1.18.9. `VERIFIED` для Hermes Agent v0.19.0. `VERIFIED` для Qwen Code 0.21.0. `EXPERIMENTAL` означает, что без калибровки расхода продвижение запрещено. `completionCheck` требует `agent-completion-check-receipt.v1`. `agent-goal-record.v1` создаёт `agent-objective-snapshot.v1`. `agent-runner-state.v1` создаёт `agent-runner-snapshot.v1`. `agent-follow-up-register.v1` создаёт `agent-follow-up-summary.v1`. `agent-worktree-isolation-policy.v1` проверяет `agent-worktree-attempt-receipt.v1`. `agent-adapter-event-stream-receipt.v1` проверяет `agent-adapter-event-capture-validation.v1`. `agent-review-verdict.v1` создаёт `agent-review-routing-summary.v1`. `agent-optional-quality-pack.v1`. `agent-behavior-check-run.v1`. `agent-diagnostic-bundle.v1`. `agent-readonly-status-view.v1`.\n",
+        "`VERIFIED` для Codex CLI 0.145.0. `VERIFIED` для Claude Code 2.1.220. `VERIFIED` для OpenCode CLI 1.18.9. `VERIFIED` для Hermes Agent v0.19.0. `VERIFIED` для Qwen Code 0.21.0. `EXPERIMENTAL` означает, что без калибровки расхода продвижение запрещено. Список в Публичных контрактах: reference/public-contracts.md. `completionCheck` требует `agent-completion-check-receipt.v1`. `agent-goal-record.v1` создаёт `agent-objective-snapshot.v1`. `agent-runner-state.v1` создаёт `agent-runner-snapshot.v1`. `agent-follow-up-register.v1` создаёт `agent-follow-up-summary.v1`. `agent-worktree-isolation-policy.v1` проверяет `agent-worktree-attempt-receipt.v1`. `agent-adapter-event-stream-receipt.v1` проверяет `agent-adapter-event-capture-validation.v1`. `agent-review-verdict.v1` создаёт `agent-review-routing-summary.v1`. `agent-optional-quality-pack.v1`. `agent-behavior-check-run.v1`. `agent-diagnostic-bundle.v1`. `agent-readonly-status-view.v1`.\n",
     )
+    public_contracts = (
+        "`completionCheck`.\n"
+        "`agent-completion-check-receipt.v1`.\n"
+        "`agent-goal-record.v1`.\n"
+        "`agent-objective-snapshot.v1`.\n"
+        "`agent-runner-state.v1`.\n"
+        "`agent-runner-snapshot.v1`.\n"
+        "`agent-follow-up-register.v1`.\n"
+        "`agent-follow-up-summary.v1`.\n"
+        "`agent-worktree-isolation-policy.v1`.\n"
+        "`agent-worktree-attempt-receipt.v1`.\n"
+        "`agent-adapter-event-stream-receipt.v1`.\n"
+        "`agent-adapter-event-capture-validation.v1`.\n"
+        "`agent-review-verdict.v1`.\n"
+        "`agent-review-routing-summary.v1`.\n"
+        "`agent-optional-quality-pack.v1`.\n"
+        "`agent-behavior-check-run.v1`.\n"
+        "`agent-diagnostic-bundle.v1`.\n"
+        "`agent-readonly-status-view.v1`.\n"
+    )
+    _write_text(root / "docs/reference/public-contracts.md", public_contracts)
+    _write_text(root / "docs/ru/reference/public-contracts.md", public_contracts)
     cursor_maturity = "VERIFIED" if unsupported_verified_row else "EXPERIMENTAL"
     _write_text(
         root / "docs/adapters/support-matrix.md",
@@ -348,7 +416,7 @@ def _write_min_docs(root: Path, *, unsupported_verified_row: bool) -> None:
         "small local model.\n"
         "agent-lifecycle report status-view.\n",
     )
-    for host in ("claude", "codex", "cursor", "gemini-cli", "hermes", "kimi-code", "opencode", "qwen-code"):
+    for host in ("claude", "codex", "cursor", "gemini-cli", "goose", "hermes", "kimi-code", "opencode", "qwen-code"):
         _write_text(
             root / f"docs/adapters/{host}.md",
             (
@@ -356,6 +424,8 @@ def _write_min_docs(root: Path, *, unsupported_verified_row: bool) -> None:
                 if host == "codex"
                 else "This adapter is `VERIFIED` for Claude Code 2.1.220; live conformance exists and it does not claim official approval.\n"
                 if host == "claude"
+                else "This adapter is `VERIFIED` for Goose `1.45.0`; live conformance exists and it does not claim public approval.\n"
+                if host == "goose"
                 else "This adapter is `VERIFIED` for OpenCode CLI `1.18.9`; live conformance exists and it does not claim npm publication.\n"
                 if host == "opencode"
                 else "This adapter is `VERIFIED` for Hermes Agent `v0.19.0`; live conformance exists and it does not claim public approval.\n"

--- a/tests/release/test_release_inventory.py
+++ b/tests/release/test_release_inventory.py
@@ -68,7 +68,7 @@ class ReleaseInventoryTests(unittest.TestCase):
             self.assertEqual(matrix["adapterMaturityByHost"]["OpenCode"], "VERIFIED")
             self.assertEqual(matrix["adapterMaturityByHost"]["Hermes"], "VERIFIED")
             self.assertEqual(matrix["adapterMaturityByHost"]["Qwen Code"], "VERIFIED")
-            self.assertEqual(set(matrix["verifiedHosts"]), {"Codex", "Claude Code", "OpenCode", "Hermes", "Qwen Code"})
+            self.assertEqual(set(matrix["verifiedHosts"]), {"Codex", "Claude Code", "Goose", "OpenCode", "Hermes", "Qwen Code"})
             self.assertTrue(deferred["deferredProductionPromotion"])
             self.assertFalse(deferred["liveModelExecutionClaimed"])
 

--- a/tools/live_hosts/goose_harness.py
+++ b/tools/live_hosts/goose_harness.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agent_lifecycle.contracts import canonical_digest, sha256_hex  # noqa: E402
+from tools.live_hosts.common import (  # noqa: E402
+    BudgetPolicy,
+    CommandResult,
+    HarnessError,
+    HostModelSelection,
+    load_host_model_selection,
+)
+from tools.live_hosts.json_cli_harness import (  # noqa: E402
+    LIVE_CALIBRATION_RECEIPT_SCHEMA,
+    LIVE_HOST_RECEIPT_SCHEMA,
+    JsonCliUsage,
+    base_report,
+    build_fixture_operations,
+    file_identity,
+    first_line,
+    load_json,
+    parse_json_objects,
+    run_command,
+    run_command_capture,
+    run_fixture_check as run_json_fixture_check,
+    run_live_calibration as run_json_live_calibration,
+    run_live_host_receipt as run_json_live_host_receipt,
+    write_json,
+)
+
+
+HOST = "goose"
+HARNESS_REPORT_SCHEMA = "agent-goose-live-harness-report.v1"
+DIAGNOSTIC_SCHEMA = "agent-goose-live-invocation-diagnostic.v1"
+DEFAULT_BASELINE = Path("conformance/core/adapter-baseline.v1.json")
+DEFAULT_PROFILE = Path("conformance/core/live-calibration-profile.v1.json")
+DEFAULT_BUDGET_TARGETS = Path("conformance/core/budget-targets.v1.json")
+GooseUsage = JsonCliUsage
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["preflight", "fixture-check", "live-host-receipt", "live-calibration"], required=True)
+    parser.add_argument("--baseline", default=DEFAULT_BASELINE.as_posix())
+    parser.add_argument("--profile", default=DEFAULT_PROFILE.as_posix())
+    parser.add_argument("--budget-targets", default=DEFAULT_BUDGET_TARGETS.as_posix())
+    parser.add_argument("--goose-bin", default="goose")
+    parser.add_argument("--goose-provider")
+    parser.add_argument("--goose-model")
+    parser.add_argument("--goose-no-profile", action="store_true")
+    parser.add_argument("--host-model-profile")
+    parser.add_argument("--model-class")
+    parser.add_argument("--model-binding")
+    parser.add_argument("--model-selection-receipt")
+    parser.add_argument("--worktree")
+    parser.add_argument("--budget-mode", choices=["metered", "subscription", "local"], default="metered")
+    parser.add_argument("--budget-cap-usd", type=float)
+    parser.add_argument("--max-invocations", type=int)
+    parser.add_argument("--max-billable-tokens", type=int)
+    parser.add_argument("--max-wall-seconds", type=float)
+    parser.add_argument("--invocation-timeout-seconds", type=float, default=600.0)
+    parser.add_argument("--runs-per-scenario-cohort", type=int)
+    parser.add_argument("--allow-live", action="store_true")
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--receipt")
+    parser.add_argument("--containment-receipt")
+    parser.add_argument("--diagnostic-dir", default="work/release-1-16/evidence/live-host-diagnostics/goose")
+    args = parser.parse_args(argv)
+
+    blockers: list[dict[str, Any]] = []
+    try:
+        report = _dispatch(args)
+    except HarnessError as error:
+        blockers.append({"code": error.code, "message": error.message})
+        report = base_report(HARNESS_REPORT_SCHEMA, "FAIL", HOST, blockers)
+    write_json(Path(args.report), report)
+    return 0 if report.get("status") == "PASS" else 1
+
+
+def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
+    budget_policy = BudgetPolicy(
+        mode=args.budget_mode,
+        budget_cap_usd=args.budget_cap_usd,
+        max_invocations=args.max_invocations,
+        max_billable_tokens=args.max_billable_tokens,
+        max_wall_seconds=args.max_wall_seconds,
+    )
+    model_selection = _model_selection_from_args(args)
+    if args.mode == "preflight":
+        return run_preflight(
+            goose_bin=args.goose_bin,
+            baseline_path=Path(args.baseline),
+            worktree=Path(args.worktree) if args.worktree else None,
+            budget_policy=budget_policy,
+            allow_live=args.allow_live,
+            goose_provider=args.goose_provider,
+            goose_model=args.goose_model,
+            goose_no_profile=args.goose_no_profile,
+            containment_receipt_path=Path(args.containment_receipt) if args.containment_receipt else None,
+            model_selection=model_selection,
+        )
+    if args.mode == "fixture-check":
+        return run_fixture_check(Path(args.baseline))
+    if args.mode == "live-host-receipt":
+        return run_live_host_receipt(
+            baseline_path=Path(args.baseline),
+            worktree=Path(args.worktree) if args.worktree else None,
+            allow_live=args.allow_live,
+            receipt_path=Path(args.receipt) if args.receipt else None,
+            diagnostic_dir=Path(args.diagnostic_dir),
+            budget_policy=budget_policy,
+            goose_bin=args.goose_bin,
+            goose_provider=args.goose_provider,
+            goose_model=args.goose_model,
+            goose_no_profile=args.goose_no_profile,
+            invocation_timeout_seconds=args.invocation_timeout_seconds,
+            model_selection=model_selection,
+            model_selection_receipt_path=Path(args.model_selection_receipt) if args.model_selection_receipt else None,
+        )
+    return run_live_calibration(
+        profile_path=Path(args.profile),
+        budget_targets_path=Path(args.budget_targets),
+        worktree=Path(args.worktree) if args.worktree else None,
+        runs_per_scenario_cohort=args.runs_per_scenario_cohort,
+        allow_live=args.allow_live,
+        receipt_path=Path(args.receipt) if args.receipt else None,
+        diagnostic_dir=Path(args.diagnostic_dir),
+        budget_policy=budget_policy,
+        goose_bin=args.goose_bin,
+        goose_provider=args.goose_provider,
+        goose_model=args.goose_model,
+        goose_no_profile=args.goose_no_profile,
+        invocation_timeout_seconds=args.invocation_timeout_seconds,
+        model_selection=model_selection,
+        model_selection_receipt_path=Path(args.model_selection_receipt) if args.model_selection_receipt else None,
+    )
+
+
+def run_preflight(
+    *,
+    goose_bin: str,
+    baseline_path: Path,
+    worktree: Path | None,
+    budget_policy: BudgetPolicy,
+    allow_live: bool,
+    goose_provider: str | None = None,
+    goose_model: str | None = None,
+    goose_no_profile: bool = False,
+    containment_receipt_path: Path | None = None,
+    model_selection: HostModelSelection | None = None,
+) -> dict[str, Any]:
+    blockers: list[dict[str, Any]] = []
+    checks: list[dict[str, Any]] = []
+    version = run_command([goose_bin, "--version"], checks, "goose-version")
+    help_result = run_command([goose_bin, "--help"], checks, "goose-help")
+    run_help = run_command([goose_bin, "run", "--help"], checks, "goose-run-help")
+    acp_help = run_command([goose_bin, "acp", "--help"], checks, "goose-acp-help")
+    info_result = run_command([goose_bin, "info"], checks, "goose-info")
+    baseline = load_json(baseline_path)
+    operations = _required_operations(baseline)
+    containment_policy = _containment_policy(
+        goose_provider=goose_provider,
+        goose_model=goose_model,
+        goose_no_profile=goose_no_profile,
+        model_selection=model_selection,
+    )
+    if not operations:
+        blockers.append({"code": "invalid-adapter-baseline", "message": "adapter baseline has no required operations"})
+    _validate_containment(containment_policy, blockers)
+    if allow_live:
+        try:
+            budget_policy.require_authorized(allow_live=allow_live, required_invocations=len(operations))
+        except HarnessError as error:
+            blockers.append({"code": error.code, "message": error.message})
+    if worktree is not None:
+        clean = _check_clean_worktree(worktree)
+        checks.append({"name": "clean-worktree", "status": "PASS" if clean.get("clean") else "FAIL", "details": clean})
+        if not clean.get("clean"):
+            blockers.append({"code": "BLOCKED_DIRTY_WORKTREE", "message": "live runs require a clean dedicated worktree"})
+    checks.append({"name": "budget-gate", "status": "PASS" if allow_live and not blockers else "BLOCKED", "details": {"budgetPolicy": budget_policy.to_json(), "allowLive": allow_live}})
+    help_ok = all(result["returncode"] == 0 for result in (version, help_result, run_help, acp_help, info_result))
+    status = "PASS" if not blockers and help_ok else "FAIL"
+    if containment_receipt_path is not None:
+        write_json(containment_receipt_path, _containment_receipt(status=status, blockers=blockers, policy=containment_policy, goose_cli_version=first_line(version["stdout"])))
+    return {
+        **base_report(HARNESS_REPORT_SCHEMA, status, HOST, blockers),
+        "checks": checks,
+        "gooseCliVersion": first_line(version["stdout"]),
+        "baselineDigest": canonical_digest(baseline),
+        "requiredOperationCount": len(operations),
+        "containmentPolicy": containment_policy,
+        "containmentReceipt": file_identity(containment_receipt_path) if containment_receipt_path and containment_receipt_path.exists() else None,
+        "budgetPolicy": budget_policy.to_json(),
+        "modelSelection": model_selection.redacted_json() if model_selection else None,
+        "budgetMode": budget_policy.mode,
+        "budgetCapUsd": budget_policy.budget_cap_usd,
+        "liveCallsStarted": False,
+        "productionPromotionClaimed": False,
+    }
+
+
+def run_fixture_check(baseline_path: Path) -> dict[str, Any]:
+    return run_json_fixture_check(host=HOST, baseline_path=baseline_path, report_schema=HARNESS_REPORT_SCHEMA)
+
+
+def run_live_host_receipt(
+    *,
+    baseline_path: Path,
+    worktree: Path | None,
+    allow_live: bool,
+    receipt_path: Path | None,
+    diagnostic_dir: Path,
+    budget_policy: BudgetPolicy,
+    goose_bin: str = "goose",
+    goose_provider: str | None = None,
+    goose_model: str | None = None,
+    goose_no_profile: bool = False,
+    invocation_timeout_seconds: float = 600.0,
+    model_selection: HostModelSelection | None = None,
+    model_selection_receipt_path: Path | None = None,
+    runner: Callable[[list[str]], CommandResult] | None = None,
+    clean_worktree_checker: Callable[[Path], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return run_json_live_host_receipt(
+        host=HOST,
+        report_schema=HARNESS_REPORT_SCHEMA,
+        diagnostic_schema=DIAGNOSTIC_SCHEMA,
+        baseline_path=baseline_path,
+        worktree=worktree,
+        allow_live=allow_live,
+        receipt_path=receipt_path,
+        diagnostic_dir=diagnostic_dir,
+        budget_policy=budget_policy,
+        command_for_operation=lambda operation: _operation_command(goose_bin, operation, goose_provider=goose_provider, goose_model=goose_model, goose_no_profile=goose_no_profile, model_selection=model_selection),
+        usage_parser=parse_goose_stream_json,
+        invocation_timeout_seconds=invocation_timeout_seconds,
+        model_selection=model_selection,
+        model_selection_receipt_path=model_selection_receipt_path,
+        extra_blockers=_containment_blockers(goose_provider=goose_provider, goose_model=goose_model, goose_no_profile=goose_no_profile, model_selection=model_selection),
+        runner=runner,
+        clean_worktree_checker=clean_worktree_checker,
+    )
+
+
+def run_live_calibration(
+    *,
+    profile_path: Path,
+    budget_targets_path: Path,
+    worktree: Path | None,
+    runs_per_scenario_cohort: int | None,
+    allow_live: bool,
+    receipt_path: Path | None,
+    diagnostic_dir: Path,
+    budget_policy: BudgetPolicy,
+    goose_bin: str = "goose",
+    goose_provider: str | None = None,
+    goose_model: str | None = None,
+    goose_no_profile: bool = False,
+    invocation_timeout_seconds: float = 600.0,
+    model_selection: HostModelSelection | None = None,
+    model_selection_receipt_path: Path | None = None,
+    runner: Callable[[list[str]], CommandResult] | None = None,
+    clean_worktree_checker: Callable[[Path], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return run_json_live_calibration(
+        host=HOST,
+        report_schema=HARNESS_REPORT_SCHEMA,
+        diagnostic_schema=DIAGNOSTIC_SCHEMA,
+        profile_path=profile_path,
+        budget_targets_path=budget_targets_path,
+        worktree=worktree,
+        runs_per_scenario_cohort=runs_per_scenario_cohort,
+        allow_live=allow_live,
+        receipt_path=receipt_path,
+        diagnostic_dir=diagnostic_dir,
+        budget_policy=budget_policy,
+        command_for_prompt=lambda prompt: _run_command(goose_bin, prompt, goose_provider=goose_provider, goose_model=goose_model, goose_no_profile=goose_no_profile, model_selection=model_selection),
+        usage_parser=parse_goose_stream_json,
+        invocation_timeout_seconds=invocation_timeout_seconds,
+        model_selection=model_selection,
+        model_selection_receipt_path=model_selection_receipt_path,
+        extra_blockers=_containment_blockers(goose_provider=goose_provider, goose_model=goose_model, goose_no_profile=goose_no_profile, model_selection=model_selection),
+        runner=runner,
+        clean_worktree_checker=clean_worktree_checker,
+    )
+
+
+def parse_goose_stream_json(text: str, wall_seconds: float = 0.0) -> GooseUsage:
+    events = parse_json_objects(text)
+    usage: dict[str, Any] = {}
+    costs: list[float] = []
+    session_id: str | None = None
+    tool_calls = 0
+    for event in events:
+        session_id = session_id or _find_string(event, {"session_id", "sessionId", "sessionID", "conversation_id", "conversationId"})
+        candidate = event.get("metadata")
+        if not isinstance(candidate, dict):
+            candidate = event.get("usage") if isinstance(event.get("usage"), dict) else event.get("usageMetadata")
+        if isinstance(candidate, dict):
+            usage = candidate
+        costs.extend(_find_numbers(event, {"cost_usd", "costUsd", "costUSD", "cost"}))
+        tool_calls += _count_tool_calls(event)
+    input_tokens = _int_from_any(_first_present(usage, ("inputTokens", "input_tokens", "prompt_tokens", "promptTokens", "promptTokenCount")))
+    output_tokens = _int_from_any(_first_present(usage, ("outputTokens", "output_tokens", "completion_tokens", "completionTokens", "candidatesTokenCount")))
+    total_tokens = _int_from_any(_first_present(usage, ("billableTokens", "billable_tokens", "total", "total_tokens", "totalTokens", "totalTokenCount")))
+    context_bytes = _int_from_any(_first_present(usage, ("cumulativeContextBytes", "cumulative_context_bytes", "contextBytes", "context_bytes")))
+    return GooseUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        billable_tokens=total_tokens or input_tokens + output_tokens,
+        cumulative_context_bytes=context_bytes if context_bytes else None,
+        cumulative_context_bytes_source="host-json" if context_bytes else None,
+        tool_calls=tool_calls,
+        wall_seconds=round(wall_seconds, 3),
+        cost_usd=sum(costs) if costs else None,
+        session_id=session_id,
+        event_count=len(events),
+    )
+
+
+def _operation_command(goose_bin: str, operation_name: str, *, goose_provider: str | None, goose_model: str | None, goose_no_profile: bool, model_selection: HostModelSelection | None) -> list[str]:
+    return _run_command(
+        goose_bin,
+        (
+            f"ALK goose live conformance probe. Operation: {operation_name}. "
+            "Do not use tools. Do not modify files. Reply only with compact JSON: {\"operation\":\"<operation>\",\"status\":\"PASS\"}."
+        ),
+        goose_provider=goose_provider,
+        goose_model=goose_model,
+        goose_no_profile=goose_no_profile,
+        model_selection=model_selection,
+    )
+
+
+def _run_command(goose_bin: str, prompt: str, *, goose_provider: str | None, goose_model: str | None, goose_no_profile: bool, model_selection: HostModelSelection | None) -> list[str]:
+    provider = goose_provider or (model_selection.provider if model_selection is not None else None)
+    model = goose_model or (model_selection.provider_model if model_selection is not None else None)
+    command = [
+        goose_bin,
+        "run",
+        "--no-session",
+        "--max-turns",
+        "1",
+        "--max-tool-repetitions",
+        "1",
+        "--output-format",
+        "json",
+    ]
+    if goose_no_profile:
+        command.append("--no-profile")
+    if provider:
+        command.extend(["--provider", provider])
+    if model:
+        command.extend(["--model", model])
+    command.extend(["--text", prompt])
+    return command
+
+
+def _containment_blockers(*, goose_provider: str | None, goose_model: str | None, goose_no_profile: bool, model_selection: HostModelSelection | None) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    _validate_containment(
+        _containment_policy(
+            goose_provider=goose_provider,
+            goose_model=goose_model,
+            goose_no_profile=goose_no_profile,
+            model_selection=model_selection,
+        ),
+        blockers,
+    )
+    return blockers
+
+
+def _containment_policy(*, goose_provider: str | None, goose_model: str | None, goose_no_profile: bool, model_selection: HostModelSelection | None) -> dict[str, Any]:
+    provider = goose_provider or (model_selection.provider if model_selection is not None else None)
+    model = goose_model or (model_selection.provider_model if model_selection is not None else None)
+    return {
+        "schemaVersion": "agent-goose-live-containment-policy.v1",
+        "host": HOST,
+        "noSession": True,
+        "noProfile": goose_no_profile,
+        "defaultExtensionsLoaded": not goose_no_profile,
+        "cliSpecifiedExtensions": [],
+        "maxTurns": 1,
+        "maxToolRepetitions": 1,
+        "outputFormat": "json",
+        "providerOverridePresent": provider is not None,
+        "modelOverridePresent": model is not None,
+        "postInvocationCleanWorktreeRequired": True,
+        "promptPolicy": "no-tools-no-file-modifications-json-only",
+    }
+
+
+def _validate_containment(policy: dict[str, Any], blockers: list[dict[str, Any]]) -> None:
+    if policy.get("noProfile") is not True:
+        blockers.append({"code": "BLOCKED_UNBOUNDED_HOST_PROFILE", "message": "goose live promotion requires --goose-no-profile"})
+    if policy.get("providerOverridePresent") is not True or policy.get("modelOverridePresent") is not True:
+        blockers.append({"code": "BLOCKED_MODEL_BINDING_UNDECLARED", "message": "goose live promotion requires explicit host-local provider and model"})
+    if policy.get("maxTurns") != 1 or policy.get("maxToolRepetitions") != 1:
+        blockers.append({"code": "BLOCKED_UNBOUNDED_HOST_INVOCATION", "message": "goose live promotion requires bounded turns and tool repetitions"})
+
+
+def _containment_receipt(*, status: str, blockers: list[dict[str, Any]], policy: dict[str, Any], goose_cli_version: str | None) -> dict[str, Any]:
+    return {
+        "schemaVersion": "agent-goose-live-containment-receipt.v1",
+        "status": status,
+        "host": HOST,
+        "gooseCliVersion": goose_cli_version,
+        "policy": policy,
+        "blockers": blockers,
+        "productionPromotionClaimed": False,
+    }
+
+
+def _model_selection_from_args(args: argparse.Namespace) -> HostModelSelection | None:
+    if not args.host_model_profile:
+        return None
+    if not args.model_class:
+        raise HarnessError("missing-model-class", "--model-class is required with --host-model-profile")
+    return load_host_model_selection(Path(args.host_model_profile), model_class=args.model_class, binding_id=args.model_binding)
+
+
+def _check_clean_worktree(worktree: Path) -> dict[str, Any]:
+    result = run_command_capture(["git", "-C", str(worktree), "status", "--short"], timeout_seconds=30)
+    if result.returncode != 0:
+        return {"clean": False, "reason": "not-a-git-worktree", "stderrSha256": sha256_hex(result.stderr.encode("utf-8"))}
+    return {"clean": result.stdout == "", "dirtyEntryCount": len([line for line in result.stdout.splitlines() if line.strip()])}
+
+
+def _required_operations(baseline: dict[str, Any]) -> list[str]:
+    value = baseline.get("requiredOperations")
+    return [item for item in value if isinstance(item, str) and item] if isinstance(value, list) else []
+
+
+def _first_present(value: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in value:
+            return value[key]
+    return None
+
+
+def _int_from_any(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def _find_string(value: Any, keys: set[str]) -> str | None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in keys and isinstance(item, str) and item:
+                return item
+            found = _find_string(item, keys)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = _find_string(item, keys)
+            if found:
+                return found
+    return None
+
+
+def _find_numbers(value: Any, keys: set[str]) -> list[float]:
+    found: list[float] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in keys and isinstance(item, (int, float)) and not isinstance(item, bool):
+                found.append(float(item))
+            found.extend(_find_numbers(item, keys))
+    elif isinstance(value, list):
+        for item in value:
+            found.extend(_find_numbers(item, keys))
+    return found
+
+
+def _count_tool_calls(value: Any) -> int:
+    if isinstance(value, dict):
+        total = 0
+        if value.get("type") in {"toolRequest", "toolResponse", "tool_request", "tool_response"}:
+            total += 1
+        for key, item in value.items():
+            if key in {"tool_call", "toolCall", "tool_calls", "toolCalls"}:
+                total += len(item) if isinstance(item, list) else int(isinstance(item, dict))
+            total += _count_tool_calls(item)
+        return total
+    if isinstance(value, list):
+        return sum(_count_tool_calls(item) for item in value)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/live_hosts/json_cli_harness.py
+++ b/tools/live_hosts/json_cli_harness.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable
+
+from agent_lifecycle.contracts import LifecycleError, canonical_digest, sha256_hex
+from agent_lifecycle.host_protocol import HostOperationReceipt, HostOperationRequest
+from tools.live_hosts.common import (
+    BudgetPolicy,
+    BudgetTracker,
+    CommandResult,
+    HarnessError,
+    HostModelSelection,
+    write_model_selection_receipt,
+)
+
+
+LIVE_HOST_RECEIPT_SCHEMA = "agent-lifecycle-live-host-conformance-receipt.v1"
+LIVE_CALIBRATION_RECEIPT_SCHEMA = "agent-lifecycle-live-calibration-receipt.v1"
+
+
+@dataclass(frozen=True)
+class JsonCliUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    billable_tokens: int = 0
+    cumulative_context_bytes: int | None = None
+    tool_calls: int = 0
+    wall_seconds: float = 0.0
+    cost_usd: float | None = None
+    session_id: str | None = None
+    event_count: int = 0
+    cumulative_context_bytes_source: str | None = None
+
+    @property
+    def has_usage_attestation(self) -> bool:
+        return bool(self.billable_tokens or self.input_tokens or self.output_tokens or self.cost_usd is not None)
+
+    @property
+    def has_calibration_attestation(self) -> bool:
+        return self.has_usage_attestation and self.cumulative_context_bytes is not None
+
+    def to_receipt_usage(self) -> dict[str, Any]:
+        usage: dict[str, Any] = {
+            "inputTokens": self.input_tokens,
+            "outputTokens": self.output_tokens,
+            "billableTokens": self.billable_tokens,
+            "toolCalls": self.tool_calls,
+            "wallSeconds": self.wall_seconds,
+        }
+        if self.cost_usd is not None:
+            usage["costUsd"] = self.cost_usd
+        if self.session_id:
+            usage["sessionId"] = self.session_id
+        return usage
+
+    def to_calibration_usage(self) -> dict[str, Any]:
+        usage = {
+            "billableTokens": self.billable_tokens,
+            "inputTokens": self.input_tokens,
+            "outputTokens": self.output_tokens,
+            "cumulativeContextBytes": self.cumulative_context_bytes if self.cumulative_context_bytes is not None else 0,
+            "toolCalls": self.tool_calls,
+            "wallSeconds": self.wall_seconds,
+        }
+        if self.cumulative_context_bytes_source:
+            usage["cumulativeContextBytesSource"] = self.cumulative_context_bytes_source
+        if self.session_id:
+            usage["sessionId"] = self.session_id
+        return usage
+
+    def with_context_byte_proxy(self, value: int) -> "JsonCliUsage":
+        return replace(
+            self,
+            cumulative_context_bytes=value,
+            cumulative_context_bytes_source="harness-observed-prompt-and-json-output-bytes",
+        )
+
+
+CommandBuilder = Callable[[str], list[str]]
+UsageParser = Callable[[str, float], JsonCliUsage]
+CleanWorktreeChecker = Callable[[Path], dict[str, Any]]
+
+
+def run_fixture_check(*, host: str, baseline_path: Path, report_schema: str) -> dict[str, Any]:
+    baseline = load_json(baseline_path)
+    operations = build_fixture_operations(host, baseline)
+    blockers: list[dict[str, Any]] = []
+    for operation in operations:
+        try:
+            HostOperationRequest.from_json(operation["hostOperationRequest"])
+            HostOperationReceipt.from_json(operation["hostOperationReceipt"])
+        except LifecycleError as error:
+            blockers.append({"code": "host-protocol-envelope-invalid", "message": f"{operation.get('name')}: {error.code}"})
+    required = set(required_operations(baseline))
+    actual = {operation.get("name") for operation in operations}
+    missing = sorted(required - actual)
+    if missing:
+        blockers.append({"code": "fixture-operation-missing", "message": ", ".join(missing)})
+    return {
+        **base_report(report_schema, "PASS" if not blockers else "FAIL", host, blockers),
+        "checks": [{"name": "fixture-host-operation-envelopes", "status": "PASS" if not blockers else "FAIL", "details": {"operationCount": len(operations), "syntheticFixtureOnly": True}}],
+        "baselineDigest": canonical_digest(baseline),
+        "requiredOperationCount": len(required),
+        "operationCount": len(operations),
+        "syntheticFixtureOnly": True,
+        "productionPromotionClaimed": False,
+    }
+
+
+def run_live_host_receipt(
+    *,
+    host: str,
+    report_schema: str,
+    diagnostic_schema: str,
+    baseline_path: Path,
+    worktree: Path | None,
+    allow_live: bool,
+    receipt_path: Path | None,
+    diagnostic_dir: Path,
+    budget_policy: BudgetPolicy,
+    command_for_operation: CommandBuilder,
+    usage_parser: UsageParser,
+    invocation_timeout_seconds: float = 600.0,
+    model_selection: HostModelSelection | None = None,
+    model_selection_receipt_path: Path | None = None,
+    extra_blockers: list[dict[str, Any]] | None = None,
+    runner: Callable[[list[str]], CommandResult] | None = None,
+    clean_worktree_checker: CleanWorktreeChecker | None = None,
+) -> dict[str, Any]:
+    clean_worktree_checker = clean_worktree_checker or check_clean_worktree
+    blockers = list(extra_blockers or [])
+    checks: list[dict[str, Any]] = []
+    baseline = load_json(baseline_path)
+    operations = required_operations(baseline)
+    validate_live_inputs(blockers, checks, budget_policy, allow_live, len(operations), worktree, clean_worktree_checker, receipt_path, "live-host-receipt")
+    validate_model_selection_inputs(blockers, model_selection, model_selection_receipt_path)
+    if blockers:
+        return blocked_live_report(report_schema, host, blockers, checks, budget_policy, model_selection=model_selection)
+
+    assert worktree is not None
+    assert receipt_path is not None
+    command_runner = runner or (lambda command: run_command_capture(command, cwd=worktree, timeout_seconds=invocation_timeout_seconds))
+    diagnostic_dir.mkdir(parents=True, exist_ok=True)
+    live_operations: list[dict[str, Any]] = []
+    budget_tracker = BudgetTracker()
+    live_calls_started = False
+    for index, operation_name in enumerate(operations, start=1):
+        try:
+            budget_policy.require_before_invocation(budget_tracker)
+        except HarnessError as error:
+            blockers.append({"code": error.code, "message": error.message})
+            break
+        invocation_id = f"{host}-{operation_name}-live-{index:02d}"
+        result = command_runner(command_for_operation(operation_name))
+        live_calls_started = True
+        transcript = write_invocation_diagnostic(diagnostic_dir, operation_name, invocation_id, result, diagnostic_schema)
+        checks.append({"name": f"{host}-live-{operation_name}", "status": "PASS" if result.returncode == 0 else "FAIL", "details": {"returncode": result.returncode, "diagnostic": display_path(transcript)}})
+        record_post_invocation_cleanliness(checks, blockers, worktree, clean_worktree_checker, f"{host}-post-live-{operation_name}", host)
+        if blockers:
+            break
+        usage = usage_or_block(result, budget_policy, blockers, operation_name, usage_parser, host)
+        if usage is None:
+            break
+        try:
+            budget_tracker.record(usage, budget_policy)
+        except HarnessError as error:
+            blockers.append({"code": error.code, "message": error.message})
+            break
+        live_operations.append(build_live_operation_record(host=host, name=operation_name, invocation_id=invocation_id, usage=usage, output_identity=file_identity(transcript)))
+
+    if not blockers and set(operation["name"] for operation in live_operations) != set(operations):
+        blockers.append({"code": "live-host-operation-missing", "message": "not all baseline operations were executed"})
+    if not blockers:
+        model_selection_identity = write_optional_model_selection(model_selection, model_selection_receipt_path)
+        write_json(
+            receipt_path,
+            {
+                "schemaVersion": LIVE_HOST_RECEIPT_SCHEMA,
+                "status": "PASS",
+                "receiptId": f"{host}-live-host-conformance",
+                "host": host,
+                "adapterId": host,
+                "sourceRevision": source_revision(),
+                "syntheticReplayUsed": False,
+                "usageAttested": True,
+                "budgetPolicy": budget_policy.to_json(),
+                "budgetUsage": budget_tracker.to_json(),
+                "modelSelection": model_selection.redacted_json() if model_selection else None,
+                "modelSelectionReceipt": model_selection_identity,
+                "budgetMode": budget_policy.mode,
+                "budgetCapUsd": budget_policy.budget_cap_usd,
+                "cumulativeCostUsd": budget_tracker.cost_usd,
+                "operations": live_operations,
+            },
+        )
+    return live_report(report_schema, host, "PASS" if not blockers else "FAIL", blockers, checks, budget_policy, budget_tracker, live_calls_started, len(operations), len(live_operations), receipt_path, model_selection=model_selection, model_selection_receipt_path=model_selection_receipt_path)
+
+
+def run_live_calibration(
+    *,
+    host: str,
+    report_schema: str,
+    diagnostic_schema: str,
+    profile_path: Path,
+    budget_targets_path: Path,
+    worktree: Path | None,
+    runs_per_scenario_cohort: int | None,
+    allow_live: bool,
+    receipt_path: Path | None,
+    diagnostic_dir: Path,
+    budget_policy: BudgetPolicy,
+    command_for_prompt: CommandBuilder,
+    usage_parser: UsageParser,
+    invocation_timeout_seconds: float = 600.0,
+    model_selection: HostModelSelection | None = None,
+    model_selection_receipt_path: Path | None = None,
+    extra_blockers: list[dict[str, Any]] | None = None,
+    runner: Callable[[list[str]], CommandResult] | None = None,
+    clean_worktree_checker: CleanWorktreeChecker | None = None,
+) -> dict[str, Any]:
+    clean_worktree_checker = clean_worktree_checker or check_clean_worktree
+    blockers = list(extra_blockers or [])
+    checks: list[dict[str, Any]] = []
+    profile = load_json(profile_path)
+    targets = load_json(budget_targets_path)
+    scenarios = strings(profile.get("requiredScenarios"))
+    cohorts = strings(profile.get("requiredCohorts"))
+    minimum_runs = positive_int(profile.get("minimumRunsPerScenarioCohort")) or 1
+    requested_runs = runs_per_scenario_cohort or minimum_runs
+    required_invocations = len(scenarios) * len(cohorts) * requested_runs
+    validate_calibration_inputs(profile, targets, blockers, scenarios, cohorts, requested_runs, minimum_runs, host)
+    validate_live_inputs(blockers, checks, budget_policy, allow_live, required_invocations, worktree, clean_worktree_checker, receipt_path, "live-calibration")
+    validate_model_selection_inputs(blockers, model_selection, model_selection_receipt_path)
+    if blockers:
+        return blocked_live_report(report_schema, host, blockers, checks, budget_policy, model_selection=model_selection)
+
+    assert worktree is not None
+    assert receipt_path is not None
+    command_runner = runner or (lambda command: run_command_capture(command, cwd=worktree, timeout_seconds=invocation_timeout_seconds))
+    diagnostic_dir.mkdir(parents=True, exist_ok=True)
+    runs: list[dict[str, Any]] = []
+    budget_tracker = BudgetTracker()
+    live_calls_started = False
+    for scenario in scenarios:
+        for cohort in cohorts:
+            for run_index in range(1, requested_runs + 1):
+                try:
+                    budget_policy.require_before_invocation(budget_tracker)
+                except HarnessError as error:
+                    blockers.append({"code": error.code, "message": error.message})
+                    break
+                invocation_id = f"{host}-{scenario}-{cohort}-{run_index:02d}"
+                prompt = prompt_for_calibration(host, scenario, cohort, run_index)
+                result = command_runner(command_for_prompt(prompt))
+                live_calls_started = True
+                transcript = write_invocation_diagnostic(diagnostic_dir, f"{scenario}-{cohort}-{run_index:02d}", invocation_id, result, diagnostic_schema)
+                checks.append({"name": f"{host}-calibration-{scenario}-{cohort}-{run_index:02d}", "status": "PASS" if result.returncode == 0 else "FAIL", "details": {"returncode": result.returncode, "diagnostic": display_path(transcript)}})
+                record_post_invocation_cleanliness(checks, blockers, worktree, clean_worktree_checker, f"{host}-post-calibration-{scenario}-{cohort}-{run_index:02d}", host)
+                if blockers:
+                    break
+                usage = calibration_usage_or_block(result, budget_policy, blockers, f"{scenario}/{cohort}/{run_index}", prompt, usage_parser, host)
+                if usage is None:
+                    break
+                try:
+                    budget_tracker.record(usage, budget_policy)
+                except HarnessError as error:
+                    blockers.append({"code": error.code, "message": error.message})
+                    break
+                runs.append({"runId": invocation_id, "scenarioId": scenario, "cohort": cohort, "usageAttested": True, "qualityStatus": "PASS", "usage": usage.to_calibration_usage()})
+            if blockers:
+                break
+        if blockers:
+            break
+
+    if not blockers:
+        model_selection_identity = write_optional_model_selection(model_selection, model_selection_receipt_path)
+        write_json(
+            receipt_path,
+            {
+                "schemaVersion": LIVE_CALIBRATION_RECEIPT_SCHEMA,
+                "status": "PASS",
+                "receiptId": f"{host}-live-calibration",
+                "host": host,
+                "profileId": profile.get("profileId"),
+                "profileDigest": canonical_digest(profile),
+                "budgetTargetsDigest": canonical_digest(targets),
+                "sourceRevision": source_revision(),
+                "liveModelInvocations": len(runs),
+                "syntheticReplayUsed": False,
+                "qualityRegressionCount": 0,
+                "usageAttestationPolicy": budget_policy.usage_attestation_policy(f"{host}-json"),
+                "contextByteAccounting": "host-json-or-harness-observed-prompt-and-output-bytes",
+                "budgetPolicy": budget_policy.to_json(),
+                "modelSelection": model_selection.redacted_json() if model_selection else None,
+                "modelSelectionReceipt": model_selection_identity,
+                "budgetUsage": budget_tracker.to_json(),
+                "budgetMode": budget_policy.mode,
+                "budgetCapUsd": budget_policy.budget_cap_usd,
+                "cumulativeCostUsd": budget_tracker.cost_usd,
+                "runs": runs,
+            },
+        )
+    report = live_report(report_schema, host, "PASS" if not blockers else "FAIL", blockers, checks, budget_policy, budget_tracker, live_calls_started, required_invocations, len(runs), receipt_path, model_selection=model_selection, model_selection_receipt_path=model_selection_receipt_path)
+    return {**report, "profileDigest": canonical_digest(profile), "budgetTargetsDigest": canonical_digest(targets), "requiredScenarioCount": len(scenarios), "requiredCohortCount": len(cohorts), "runsPerScenarioCohort": requested_runs}
+
+
+def build_fixture_operations(host: str, baseline: dict[str, Any]) -> list[dict[str, Any]]:
+    operations: list[dict[str, Any]] = []
+    for name in required_operations(baseline):
+        operation_id = f"{host}-{name}-fixture"
+        request = HostOperationRequest(operation_id=operation_id, capability=name, inputs={"host": host, "fixture": True}, outputs=[], constraints={"usageReceiptRequired": True, "syntheticFixtureOnly": True})
+        receipt = HostOperationReceipt(operation_id=operation_id, capability=name, status="PASS", outputs=[], usage={"toolCalls": 0, "billableTokens": 0, "syntheticFixtureOnly": True})
+        operations.append({"name": name, "status": "PASS", "syntheticReplayUsed": True, "hostOperationRequest": request.to_json(), "hostOperationReceipt": receipt.to_json()})
+    return operations
+
+
+def build_live_operation_record(*, host: str, name: str, invocation_id: str, usage: JsonCliUsage, output_identity: dict[str, Any]) -> dict[str, Any]:
+    request = HostOperationRequest(operation_id=invocation_id, capability=name, inputs={"host": host}, outputs=[output_identity], constraints={"usageReceiptRequired": True, "syntheticReplayForbidden": True})
+    receipt = HostOperationReceipt(operation_id=invocation_id, capability=name, status="PASS", outputs=[output_identity], usage=usage.to_receipt_usage())
+    return {"name": name, "status": "PASS", "syntheticReplayUsed": False, "hostOperationRequest": request.to_json(), "hostOperationReceipt": receipt.to_json()}
+
+
+def parse_json_objects(text: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    decoder = json.JSONDecoder()
+    index = 0
+    while index < len(text):
+        start = text.find("{", index)
+        if start == -1:
+            break
+        try:
+            value, end = decoder.raw_decode(text[start:])
+        except json.JSONDecodeError:
+            index = start + 1
+            continue
+        if isinstance(value, dict):
+            events.append(value)
+        index = start + max(end, 1)
+    return events
+
+
+def check_clean_worktree(worktree: Path) -> dict[str, Any]:
+    if not worktree.exists():
+        return {"clean": False, "reason": "missing-worktree"}
+    result = subprocess.run(["git", "-C", str(worktree), "status", "--short"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if result.returncode != 0:
+        return {"clean": False, "reason": "not-a-git-worktree", "stderrSha256": sha256_hex(result.stderr.encode("utf-8"))}
+    return {"clean": result.stdout == "", "dirtyEntryCount": len([line for line in result.stdout.splitlines() if line.strip()])}
+
+
+def run_command_capture(command: list[str], *, cwd: Path | None = None, timeout_seconds: float | None = None) -> CommandResult:
+    started = time.monotonic()
+    try:
+        result = subprocess.run(command, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout_seconds, check=False)
+    except subprocess.TimeoutExpired as error:
+        return CommandResult(
+            returncode=124,
+            stdout=error.stdout if isinstance(error.stdout, str) else "",
+            stderr=error.stderr if isinstance(error.stderr, str) else f"timed out after {timeout_seconds} seconds",
+            wall_seconds=round(time.monotonic() - started, 3),
+        )
+    return CommandResult(returncode=result.returncode, stdout=result.stdout, stderr=result.stderr, wall_seconds=round(time.monotonic() - started, 3))
+
+
+def required_operations(baseline: dict[str, Any]) -> list[str]:
+    return strings(baseline.get("requiredOperations"))
+
+
+def validate_live_inputs(
+    blockers: list[dict[str, Any]],
+    checks: list[dict[str, Any]],
+    budget_policy: BudgetPolicy,
+    allow_live: bool,
+    required_invocations: int,
+    worktree: Path | None,
+    clean_worktree_checker: CleanWorktreeChecker,
+    receipt_path: Path | None,
+    mode: str,
+) -> None:
+    try:
+        budget_policy.require_authorized(allow_live=allow_live, required_invocations=required_invocations)
+    except HarnessError as error:
+        blockers.append({"code": error.code, "message": error.message})
+    if worktree is None:
+        blockers.append({"code": "BLOCKED_DIRTY_WORKTREE", "message": "a clean dedicated worktree is required for live calls"})
+    else:
+        clean = clean_worktree_checker(worktree)
+        checks.append({"name": "clean-worktree", "status": "PASS" if clean.get("clean") else "FAIL", "details": clean})
+        if not clean.get("clean"):
+            blockers.append({"code": "BLOCKED_DIRTY_WORKTREE", "message": "live runs require a clean dedicated worktree"})
+    if receipt_path is None:
+        blockers.append({"code": f"missing-{mode}-receipt-path", "message": f"--receipt is required in {mode} mode"})
+
+
+def validate_calibration_inputs(
+    profile: dict[str, Any],
+    targets: dict[str, Any],
+    blockers: list[dict[str, Any]],
+    scenarios: list[str],
+    cohorts: list[str],
+    requested_runs: int,
+    minimum_runs: int,
+    host: str,
+) -> None:
+    if profile.get("requiredReceiptSchemaVersion") != LIVE_CALIBRATION_RECEIPT_SCHEMA:
+        blockers.append({"code": "invalid-live-calibration-profile", "message": "profile requires an unsupported receipt schema"})
+    if host not in strings(profile.get("requiredHosts")):
+        blockers.append({"code": "live-calibration-host-unsupported", "message": f"{host} is not in requiredHosts"})
+    if set(scenarios) != set(strings(targets.get("corpus"))):
+        blockers.append({"code": "live-calibration-corpus-mismatch", "message": "profile scenarios must match budget target corpus"})
+    if set(cohorts) != set(strings(targets.get("cohorts"))):
+        blockers.append({"code": "live-calibration-cohort-mismatch", "message": "profile cohorts must match budget target cohorts"})
+    if requested_runs < minimum_runs:
+        blockers.append({"code": "live-calibration-run-count-too-low", "message": "runs per scenario/cohort is below profile minimum"})
+
+
+def usage_or_block(result: CommandResult, budget_policy: BudgetPolicy, blockers: list[dict[str, Any]], label: str, usage_parser: UsageParser, host: str) -> JsonCliUsage | None:
+    if result.returncode != 0:
+        blockers.append({"code": f"{host}-live-invocation-failed", "message": f"{label} returned {result.returncode}"})
+        return None
+    usage = usage_parser(result.stdout, result.wall_seconds)
+    if not usage.has_usage_attestation:
+        blockers.append({"code": "BLOCKED_USAGE_ATTESTATION", "message": f"{label} did not expose trustworthy usage"})
+        return None
+    if budget_policy.usage_requires_cost() and usage.cost_usd is None:
+        blockers.append({"code": "BLOCKED_USAGE_ATTESTATION", "message": f"{label} did not expose cost accounting for USD budget reconciliation"})
+        return None
+    return usage
+
+
+def calibration_usage_or_block(result: CommandResult, budget_policy: BudgetPolicy, blockers: list[dict[str, Any]], label: str, prompt: str, usage_parser: UsageParser, host: str) -> JsonCliUsage | None:
+    usage = usage_or_block(result, budget_policy, blockers, label, usage_parser, host)
+    if usage is not None and usage.has_usage_attestation and usage.cumulative_context_bytes is None:
+        usage = usage.with_context_byte_proxy(context_byte_proxy(prompt, result))
+    if usage is not None and not usage.has_calibration_attestation:
+        blockers.append({"code": "BLOCKED_USAGE_ATTESTATION", "message": f"{label} did not expose all required usage metrics"})
+        return None
+    return usage
+
+
+def validate_model_selection_inputs(blockers: list[dict[str, Any]], model_selection: HostModelSelection | None, model_selection_receipt_path: Path | None) -> None:
+    if model_selection is not None and model_selection_receipt_path is None:
+        blockers.append({"code": "missing-model-selection-receipt-path", "message": "--model-selection-receipt is required with --host-model-profile"})
+
+
+def blocked_live_report(report_schema: str, host: str, blockers: list[dict[str, Any]], checks: list[dict[str, Any]], budget_policy: BudgetPolicy, *, model_selection: HostModelSelection | None = None) -> dict[str, Any]:
+    return {
+        **base_report(report_schema, "FAIL", host, blockers),
+        "checks": checks,
+        "budgetPolicy": budget_policy.to_json(),
+        "modelSelection": model_selection.redacted_json() if model_selection else None,
+        "budgetMode": budget_policy.mode,
+        "liveCallsStarted": False,
+        "productionPromotionClaimed": False,
+    }
+
+
+def live_report(
+    report_schema: str,
+    host: str,
+    status: str,
+    blockers: list[dict[str, Any]],
+    checks: list[dict[str, Any]],
+    budget_policy: BudgetPolicy,
+    budget_tracker: BudgetTracker,
+    live_calls_started: bool,
+    required_count: int,
+    passed_count: int,
+    receipt_path: Path,
+    *,
+    model_selection: HostModelSelection | None = None,
+    model_selection_receipt_path: Path | None = None,
+) -> dict[str, Any]:
+    return {
+        **base_report(report_schema, status, host, blockers),
+        "checks": checks,
+        "requiredOperationCount": required_count,
+        "passedOperationCount": passed_count,
+        "receipt": file_identity(receipt_path) if status == "PASS" else None,
+        "budgetPolicy": budget_policy.to_json(),
+        "budgetUsage": budget_tracker.to_json(),
+        "modelSelection": model_selection.redacted_json() if model_selection else None,
+        "modelSelectionReceipt": file_identity(model_selection_receipt_path) if status == "PASS" and model_selection_receipt_path else None,
+        "budgetMode": budget_policy.mode,
+        "budgetCapUsd": budget_policy.budget_cap_usd,
+        "cumulativeCostUsd": budget_tracker.cost_usd,
+        "liveCallsStarted": live_calls_started,
+        "productionPromotionClaimed": False,
+    }
+
+
+def run_command(command: list[str], checks: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    started = time.monotonic()
+    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    elapsed = time.monotonic() - started
+    checks.append({"name": name, "status": "PASS" if result.returncode == 0 else "FAIL", "returncode": result.returncode, "stdoutSha256": sha256_hex(result.stdout.encode("utf-8")), "stderrSha256": sha256_hex(result.stderr.encode("utf-8")), "wallSeconds": round(elapsed, 3)})
+    return {"returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def write_invocation_diagnostic(diagnostic_dir: Path, operation_name: str, invocation_id: str, result: CommandResult, schema_version: str) -> Path:
+    path = diagnostic_dir / f"{operation_name}.json"
+    write_json(path, {"schemaVersion": schema_version, "operation": operation_name, "invocationId": invocation_id, "returncode": result.returncode, "stdoutSha256": sha256_hex(result.stdout.encode("utf-8")), "stderrSha256": sha256_hex(result.stderr.encode("utf-8")), "stdoutBytes": len(result.stdout.encode("utf-8")), "stderrBytes": len(result.stderr.encode("utf-8")), "wallSeconds": result.wall_seconds})
+    return path
+
+
+def prompt_for_calibration(host: str, scenario: str, cohort: str, run_index: int) -> str:
+    return (
+        f"ALK {host} live calibration probe. "
+        f"Scenario: {scenario}. Cohort: {cohort}. Run: {run_index}. "
+        "Do not use tools. Do not modify files. Reply only with compact JSON: {\"status\":\"PASS\"}."
+    )
+
+
+def context_byte_proxy(prompt: str, result: CommandResult) -> int:
+    return len(prompt.encode("utf-8")) + len(result.stdout.encode("utf-8")) + len(result.stderr.encode("utf-8"))
+
+
+def record_post_invocation_cleanliness(checks: list[dict[str, Any]], blockers: list[dict[str, Any]], worktree: Path, clean_worktree_checker: CleanWorktreeChecker, name: str, host: str) -> None:
+    clean = clean_worktree_checker(worktree)
+    checks.append({"name": name, "status": "PASS" if clean.get("clean") else "FAIL", "details": clean})
+    if not clean.get("clean"):
+        blockers.append({"code": "BLOCKED_WORKTREE_MUTATED", "message": f"{host} live invocation left the worktree dirty"})
+
+
+def write_optional_model_selection(model_selection: HostModelSelection | None, model_selection_receipt_path: Path | None) -> dict[str, Any] | None:
+    if model_selection is None or model_selection_receipt_path is None:
+        return None
+    write_model_selection_receipt(model_selection_receipt_path, model_selection)
+    return file_identity(model_selection_receipt_path)
+
+
+def file_identity(path: Path) -> dict[str, Any]:
+    data = path.read_bytes()
+    return {"path": display_path(path), "sha256": sha256_hex(data), "bytes": len(data)}
+
+
+def display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def source_revision() -> str:
+    result = subprocess.run(["git", "rev-parse", "HEAD"], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    return "unknown"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise HarnessError("invalid-json", f"expected JSON object: {path.as_posix()}")
+    return value
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def base_report(report_schema: str, status: str, host: str, blockers: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"schemaVersion": report_schema, "status": status, "host": host, "blockers": blockers}
+
+
+def first_line(text: str) -> str | None:
+    for line in text.splitlines():
+        if line.strip():
+            return line.strip()
+    return None
+
+
+def strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def positive_int(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return None

--- a/tools/release/validate_docs_compat.py
+++ b/tools/release/validate_docs_compat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,7 @@ DOC_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "`VERIFIED` for Qwen Code 0.21.0",
             "`EXPERIMENTAL` means",
             "bounded live host conformance",
-            "usage/cost",
+            "usage/resource calibration",
             "Public contracts",
             "docs/reference/public-contracts.md",
         ),
@@ -247,6 +248,7 @@ ADAPTER_DOCS = (
     "docs/adapters/codex.md",
     "docs/adapters/cursor.md",
     "docs/adapters/gemini-cli.md",
+    "docs/adapters/goose.md",
     "docs/adapters/hermes.md",
     "docs/adapters/kimi-code.md",
     "docs/adapters/opencode.md",
@@ -260,7 +262,27 @@ VERSIONED_FEATURE_PROSE = re.compile(
     r"0\.\d+\s+line\s+adds|^#{2,}\s+0\.\d+\s+)",
     re.MULTILINE,
 )
-VERIFIED_DOC_HOSTS = {"Codex", "Claude Code", "OpenCode", "Hermes", "Qwen Code"}
+LEGACY_VERIFIED_DOC_HOSTS = {"Codex", "Claude Code", "OpenCode", "Hermes", "Qwen Code"}
+REQUIRED_VERIFIED_EVIDENCE_KINDS = {
+    "live-host-conformance",
+    "live-usage-calibration",
+    "lifecycle-final-proof",
+}
+HOST_DISPLAY_NAMES = {
+    "claude": "Claude Code",
+    "claude-code": "Claude Code",
+    "codex": "Codex",
+    "cursor": "Cursor",
+    "gemini-cli": "Gemini CLI",
+    "goose": "Goose",
+    "grok-build": "Grok Build",
+    "hermes": "Hermes",
+    "kimi-code": "Kimi Code",
+    "opencode": "OpenCode",
+    "openinterpreter": "OpenInterpreter",
+    "pi": "Pi",
+    "qwen-code": "Qwen Code",
+}
 
 
 def main() -> int:
@@ -272,11 +294,12 @@ def main() -> int:
     root = Path(args.root)
     blockers: list[dict[str, Any]] = []
     checks: list[dict[str, Any]] = []
+    verified_doc_hosts = LEGACY_VERIFIED_DOC_HOSTS | _verified_doc_hosts_from_evidence_index(root, blockers)
 
     for relative, required in DOC_RULES:
-        checks.append(_check_doc(root, relative, required, blockers))
+        checks.append(_check_doc(root, relative, required, blockers, verified_doc_hosts))
     for relative in ADAPTER_DOCS:
-        checks.append(_check_adapter_doc(root, relative, blockers))
+        checks.append(_check_adapter_doc(root, relative, blockers, verified_doc_hosts))
     checks.append(_check_versioned_feature_prose(root, blockers))
 
     evidence = {
@@ -290,7 +313,13 @@ def main() -> int:
     return 0 if not blockers else 1
 
 
-def _check_doc(root: Path, relative: str, required: tuple[str, ...], blockers: list[dict[str, Any]]) -> dict[str, Any]:
+def _check_doc(
+    root: Path,
+    relative: str,
+    required: tuple[str, ...],
+    blockers: list[dict[str, Any]],
+    verified_doc_hosts: set[str],
+) -> dict[str, Any]:
     path = root / relative
     check: dict[str, Any] = {"path": relative, "status": "PASS", "required": list(required), "identity": None}
     if not path.is_file():
@@ -303,17 +332,19 @@ def _check_doc(root: Path, relative: str, required: tuple[str, ...], blockers: l
     if missing:
         blockers.append({"code": "docs-compat-required-text-missing", "message": f"{relative} missing: {', '.join(missing)}"})
         check["status"] = "FAIL"
-    if _contains_overclaim(relative, text, blockers):
+    if _contains_overclaim(relative, text, blockers, verified_doc_hosts):
         check["status"] = "FAIL"
     return check
 
 
-def _check_adapter_doc(root: Path, relative: str, blockers: list[dict[str, Any]]) -> dict[str, Any]:
+def _check_adapter_doc(root: Path, relative: str, blockers: list[dict[str, Any]], verified_doc_hosts: set[str]) -> dict[str, Any]:
     path = root / relative
     if relative == "docs/adapters/claude.md":
         required = ("`VERIFIED`", "Claude Code 2.1.220", "live conformance", "does not claim official")
     elif relative == "docs/adapters/codex.md":
         required = ("`VERIFIED`", "Codex CLI 0.145.0", "live conformance", "does not claim public")
+    elif relative == "docs/adapters/goose.md":
+        required = ("`VERIFIED`", "Goose `1.45.0`", "live conformance", "does not claim public")
     elif relative == "docs/adapters/opencode.md":
         required = ("`VERIFIED`", "OpenCode CLI `1.18.9`", "live conformance", "does not claim npm")
     elif relative == "docs/adapters/hermes.md":
@@ -322,7 +353,7 @@ def _check_adapter_doc(root: Path, relative: str, blockers: list[dict[str, Any]]
         required = ("`VERIFIED`", "Qwen Code `0.21.0`", "live conformance", "does not claim public")
     else:
         required = ("`EXPERIMENTAL`", "live", "conformance")
-    check = _check_doc(root, relative, required, blockers)
+    check = _check_doc(root, relative, required, blockers, verified_doc_hosts)
     if path.is_file():
         text = path.read_text(encoding="utf-8")
         if (
@@ -331,6 +362,7 @@ def _check_adapter_doc(root: Path, relative: str, blockers: list[dict[str, Any]]
             not in {
                 "docs/adapters/claude.md",
                 "docs/adapters/codex.md",
+                "docs/adapters/goose.md",
                 "docs/adapters/opencode.md",
                 "docs/adapters/hermes.md",
                 "docs/adapters/qwen-code.md",
@@ -343,12 +375,12 @@ def _check_adapter_doc(root: Path, relative: str, blockers: list[dict[str, Any]]
     return check
 
 
-def _contains_overclaim(relative: str, text: str, blockers: list[dict[str, Any]]) -> bool:
+def _contains_overclaim(relative: str, text: str, blockers: list[dict[str, Any]], verified_doc_hosts: set[str]) -> bool:
     failed = False
     invalid_verified_rows = [
         row
         for row in VERIFIED_ROW.findall(text)
-        if _verified_row_host(row) not in VERIFIED_DOC_HOSTS
+        if _verified_row_host(row) not in verified_doc_hosts
     ]
     if invalid_verified_rows:
         blockers.append({"code": "docs-compat-verified-row", "message": f"{relative} contains a VERIFIED current-maturity row"})
@@ -392,6 +424,68 @@ def _check_versioned_feature_prose(root: Path, blockers: list[dict[str, Any]]) -
 def _verified_row_host(row: str) -> str:
     cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
     return cells[0] if cells else ""
+
+
+def _verified_doc_hosts_from_evidence_index(root: Path, blockers: list[dict[str, Any]]) -> set[str]:
+    index_path = root / "docs/adapters/evidence/adapter-evidence-summary.v1.json"
+    if not index_path.is_file():
+        return set()
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        blockers.append(
+            {
+                "code": "docs-compat-evidence-index-invalid-json",
+                "message": f"{index_path.relative_to(root).as_posix()} is invalid JSON: {exc.msg}",
+            }
+        )
+        return set()
+
+    verified_hosts: set[str] = set()
+    for item in index.get("adapters", []):
+        if not _has_verified_live_evidence(root, item):
+            continue
+        for key in ("adapterId", "host"):
+            value = item.get(key)
+            if isinstance(value, str):
+                verified_hosts.add(_host_display_name(value))
+        descriptor = _read_descriptor(root, item.get("adapterId"))
+        for key in ("adapterId", "host"):
+            value = descriptor.get(key)
+            if isinstance(value, str):
+                verified_hosts.add(_host_display_name(value))
+    return verified_hosts
+
+
+def _has_verified_live_evidence(root: Path, item: dict[str, Any]) -> bool:
+    if item.get("maturity") != "VERIFIED":
+        return False
+    if item.get("productionPromotionClaimed") or item.get("publicDirectoryApprovalClaimed"):
+        return False
+    if not item.get("testedHostRange"):
+        return False
+    evidence_kinds = set(item.get("evidenceKinds", []))
+    if not REQUIRED_VERIFIED_EVIDENCE_KINDS.issubset(evidence_kinds):
+        return False
+    summary_path = item.get("summaryPath")
+    return isinstance(summary_path, str) and (root / summary_path).is_file()
+
+
+def _read_descriptor(root: Path, adapter_id: Any) -> dict[str, Any]:
+    if not isinstance(adapter_id, str):
+        return {}
+    descriptor_path = root / "adapters" / adapter_id / "adapter.descriptor.json"
+    if not descriptor_path.is_file():
+        return {}
+    try:
+        descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return descriptor if isinstance(descriptor, dict) else {}
+
+
+def _host_display_name(value: str) -> str:
+    return HOST_DISPLAY_NAMES.get(value, value.replace("-", " ").title())
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11,<3.14"
 
 [[package]]
 name = "agent-lifecycle-kit"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "." }
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- Promote Goose to host-specific VERIFIED for Goose 1.45.0 on the tested ZAI GLM 5.2 binding.
- Add shared JSON CLI receipt/validation loop for Goose and future JSON-capable live harnesses.
- Make docs compatibility VERIFIED-row checks evidence-index-backed instead of hardcoding each new promoted host.
- Update adapter evidence summary, support matrix, docs, package/plugin metadata, and version to 1.16.0.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m pytest -q
- validate_adapter_conformance.py PASS
- validate_support_matrix.py PASS
- validate_docs_compat.py PASS
- validate_live_host_conformance.py PASS for Goose
- validate_live_calibration.py PASS for Goose
- agent_lifecycle adapter validate PASS for Goose
- agent_lifecycle diagnose --no-install-plans PASS
- git diff --check PASS

## Release notes
- Source release only; no production/public directory approval claim.
- USD cost is host-reported only and not a subscription/local promotion gate.