### PR TITLE
Release 1.19: Pi verified promotion

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/avksp/agent-lifecycle-kit.git",
-        "ref": "v1.18.0"
+        "ref": "v1.19.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
       "source": {
         "source": "github",
         "repo": "avksp/agent-lifecycle-kit",
-        "ref": "v1.18.0"
+        "ref": "v1.19.0"
       },
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
-    "version": "1.18.0"
+    "version": "1.19.0"
   },
   "plugins": [
     {
       "name": "agent-lifecycle-kit",
       "source": ".",
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - No changes yet.
 
+## 1.19.0 - 2026-08-01
+
+- Promoted Pi to host-specific `VERIFIED` for Pi 0.83.0 on the tested
+  host-local provider/model binding.
+- Added a bounded Pi JSONL live harness on the shared JSON CLI receipt loop,
+  with no-session, no-tools, no project-local context, offline startup and
+  clean-worktree checks.
+- Added Pi install/preflight containment, live conformance, live calibration
+  and lifecycle proof evidence summaries without public directory or
+  production promotion claims.
+
 ## 1.18.0 - 2026-08-01
 
 - Promoted OpenInterpreter to host-specific `VERIFIED` for `interpreter`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ required only for metered modes.
 | Kimi Code | `EXPERIMENTAL`; live proof requires a configured provider and model alias. |
 | Grok Build | `VERIFIED` for Grok Build 0.2.117 on the tested host-local provider/model binding. Public directory approval is not claimed. |
 | OpenInterpreter | `VERIFIED` for `interpreter` 0.0.34 on the tested host-local provider/model binding. Public directory approval is not claimed. |
-| Pi | `EXPERIMENTAL`; RPC/JSON and AGENTS/agentskills projection with no live promotion claim. |
+| Pi | `VERIFIED` for Pi 0.83.0 on the tested host-local provider/model binding. Public directory approval is not claimed. |
 
 Adapter installation and maturity details live in
 [Adapter install](docs/adapters/install.md) and

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Lifecycle skills and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Provider-neutral lifecycle kit and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/cursor/.cursor-plugin/plugin.json
+++ b/adapters/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Agent lifecycle planning, budgeted execution, adapter conformance, audit, and final proof for Cursor.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/pi/README.md
+++ b/adapters/pi/README.md
@@ -2,4 +2,12 @@
 
 This projection uses RPC/JSON plus AGENTS/agentskills metadata. The alternate protocol capability is not claimed.
 
-Maturity is `EXPERIMENTAL`. Live host conformance, usage receipts, sandbox evidence and lifecycle proof are required before any `VERIFIED` claim. Unsupported operations fail closed and lifecycle semantics stay delegated to ALK core.
+Maturity is host-specific `VERIFIED` for Pi 0.83.0 on the tested host-local
+provider/model binding. Live host conformance, usage receipts, host-env hygiene
+and lifecycle proof are recorded in
+`docs/adapters/evidence/pi-live-verified.md`.
+
+The adapter does not claim ACP support, public directory approval, production
+promotion, or sandbox containment beyond the bounded no-tools/no-session/no
+project-context live harness policy. Unsupported operations fail closed and
+lifecycle semantics stay delegated to ALK core.

--- a/adapters/pi/adapter.descriptor.json
+++ b/adapters/pi/adapter.descriptor.json
@@ -40,12 +40,33 @@
       "transport": "unknown"
     }
   ],
-  "liveTestedHostRange": null,
-  "maturity": "EXPERIMENTAL",
+  "liveTestedHostRange": {
+    "host": "pi",
+    "minimumVersion": "0.83.0",
+    "maximumVersion": "0.83.0",
+    "evidence": [
+      "docs/adapters/evidence/pi-live-verified.md",
+      "work/release-1-19/evidence/pi-install-probe.json",
+      "work/release-1-19/evidence/preflight/pi-preflight-report-live-ready.json",
+      "work/release-1-19/evidence/pi-containment-receipt-live-ready.json",
+      "work/release-1-19/evidence/live-host-receipts/pi.json",
+      "work/release-1-19/evidence/live-host-conformance-pi.json",
+      "work/release-1-19/evidence/live-calibration-receipts/pi.json",
+      "work/release-1-19/evidence/live-calibration-verification-pi.json",
+      "work/release-1-19/evidence/host-env-hygiene-pi-harness-reports.json",
+      "work/release-1-19/evidence/host-env-hygiene-pi-all-scanned.json",
+      "work/release-1-19/evidence/pi/full-lifecycle/final/final-proof.json"
+    ],
+    "testedAt": "2026-08-01",
+    "productionPromotionClaimed": false,
+    "publicDirectoryApprovalClaimed": false,
+    "sourceRevision": "75317878358a3dffa4b503cdb8bd8fff40de770b"
+  },
+  "maturity": "VERIFIED",
   "modelRouting": {
     "attemptRoutePolicy": "must-execute-or-fail-closed",
     "criticalReviewPolicy": "requires-strong-or-calibrated-local-review",
-    "liveVerified": false,
+    "liveVerified": true,
     "profileSupport": "host-local",
     "providerModelNamesInCore": false,
     "status": "workflow-enforced",

--- a/adapters/pi/capabilities.manifest.json
+++ b/adapters/pi/capabilities.manifest.json
@@ -129,7 +129,7 @@
     }
   ],
   "coreSemantics": "delegated-to-agent-lifecycle-core",
-  "descriptorDigest": "cd88eec16978a7a01a445021820cd0ea7e75999b98c26118139a253c0e025fc7",
+  "descriptorDigest": "d40d694ce18ec45546d619eef5a11b12327e2197a013ad850d89c7202b04a82f",
   "eventCapture": {
     "categories": [
       "command",
@@ -159,10 +159,10 @@
       "transport": "unknown"
     }
   ],
-  "maturity": "EXPERIMENTAL",
+  "maturity": "VERIFIED",
   "modelRouting": {
     "attemptRoutePolicy": "must-execute-or-fail-closed",
-    "liveVerified": false,
+    "liveVerified": true,
     "profileSupport": "host-local",
     "providerModelNamesInCore": false,
     "unsupportedClassPolicy": "fail-closed",
@@ -170,7 +170,29 @@
   },
   "promotion": {
     "productionPromotionClaimed": false,
-    "verifiedRequiresLiveTestedHostRange": true
+    "verifiedRequiresLiveTestedHostRange": true,
+    "liveTestedHostRange": {
+      "host": "pi",
+      "minimumVersion": "0.83.0",
+      "maximumVersion": "0.83.0",
+      "evidence": [
+        "docs/adapters/evidence/pi-live-verified.md",
+        "work/release-1-19/evidence/pi-install-probe.json",
+        "work/release-1-19/evidence/preflight/pi-preflight-report-live-ready.json",
+        "work/release-1-19/evidence/pi-containment-receipt-live-ready.json",
+        "work/release-1-19/evidence/live-host-receipts/pi.json",
+        "work/release-1-19/evidence/live-host-conformance-pi.json",
+        "work/release-1-19/evidence/live-calibration-receipts/pi.json",
+        "work/release-1-19/evidence/live-calibration-verification-pi.json",
+        "work/release-1-19/evidence/host-env-hygiene-pi-harness-reports.json",
+        "work/release-1-19/evidence/host-env-hygiene-pi-all-scanned.json",
+        "work/release-1-19/evidence/pi/full-lifecycle/final/final-proof.json"
+      ],
+      "testedAt": "2026-08-01",
+      "productionPromotionClaimed": false,
+      "publicDirectoryApprovalClaimed": false,
+      "sourceRevision": "75317878358a3dffa4b503cdb8bd8fff40de770b"
+    }
   },
   "runtimeBoundary": {
     "hostSpecificCode": "adapter-owned",

--- a/conformance/adapters/pi/event-stream-receipt.json
+++ b/conformance/adapters/pi/event-stream-receipt.json
@@ -1,6 +1,6 @@
 {
   "adapterId": "pi",
-  "descriptorDigest": "cd88eec16978a7a01a445021820cd0ea7e75999b98c26118139a253c0e025fc7",
+  "descriptorDigest": "d40d694ce18ec45546d619eef5a11b12327e2197a013ad850d89c7202b04a82f",
   "emittedAt": "2026-07-31T00:23:00Z",
   "eventCount": 6,
   "eventStreamDigest": "d810ba2ada1f51876732fa74dbcb472f25355438839a00899c7d924b2d216c36",
@@ -20,10 +20,10 @@
     "portableEventSchema": "agent-adapter-event.v1"
   },
   "productionPromotionClaimed": false,
-  "receiptDigest": "dfc26961cc27782220ae3d62cbf278341b16be1bf96c42a141ee13a9e7013a56",
   "runId": "offline-conformance",
   "schemaVersion": "agent-adapter-event-stream-receipt.v1",
   "status": "PASS",
   "taskId": "adapter-event-capture",
-  "terminalEvent": "task.completed"
+  "terminalEvent": "task.completed",
+  "receiptDigest": "4f6a4028d494261c2327858a7eb2c803b9a316075b17bf288cb78a8a46268499"
 }

--- a/conformance/core/live-calibration-profile.v1.json
+++ b/conformance/core/live-calibration-profile.v1.json
@@ -13,6 +13,7 @@
     "kimi-code",
     "opencode",
     "openinterpreter",
+    "pi",
     "qwen-code"
   ],
   "requiredScenarios": [

--- a/docs/adapters/evidence/adapter-evidence-summary.v1.json
+++ b/docs/adapters/evidence/adapter-evidence-summary.v1.json
@@ -173,14 +173,16 @@
     {
       "adapterId": "pi",
       "host": "pi",
-      "maturity": "EXPERIMENTAL",
-      "testedHostRange": null,
-      "summaryPath": "docs/adapters/evidence/pi-1.13.0.md",
+      "maturity": "VERIFIED",
+      "testedHostRange": "0.83.0",
+      "summaryPath": "docs/adapters/evidence/pi-live-verified.md",
       "rawEvidenceLocalOnly": true,
       "evidenceKinds": [
-        "offline-conformance",
-        "rpc-json-projection",
-        "agentskills-projection"
+        "live-host-conformance",
+        "live-usage-calibration",
+        "lifecycle-final-proof",
+        "bounded-containment",
+        "host-env-hygiene"
       ],
       "productionPromotionClaimed": false,
       "publicDirectoryApprovalClaimed": false

--- a/docs/adapters/evidence/pi-live-verified.md
+++ b/docs/adapters/evidence/pi-live-verified.md
@@ -1,0 +1,70 @@
+# Pi live evidence
+
+Status: `VERIFIED` for Pi 0.83.0 on the tested host-local provider/model
+binding.
+
+Scope:
+
+- Host: Pi 0.83.0.
+- Provider/model binding: host-local, redacted in committed docs.
+- Adapter descriptor: `adapters/pi/adapter.descriptor.json`.
+- Capability manifest: `adapters/pi/capabilities.manifest.json`.
+- Source revision used for live receipts:
+  `75317878358a3dffa4b503cdb8bd8fff40de770b`.
+- Production promotion claimed: false.
+- Public package or directory approval claimed: false.
+
+Accepted evidence:
+
+- Install/source probe: `PASS`.
+  `work/release-1-19/evidence/pi-install-probe.json`
+  (`sha256:77b4d4744777aa29df2e208851ed68d96e473036a96a5a5daff561503bd17791`).
+- Preflight: `PASS`.
+  `work/release-1-19/evidence/preflight/pi-preflight-report-live-ready.json`
+  (`sha256:c2b220fc798916b699baff201ff56f1034c56e0de36a8f26a6701355d61e5820`).
+- Bounded containment receipt: `PASS`.
+  `work/release-1-19/evidence/pi-containment-receipt-live-ready.json`
+  (`sha256:cfd61eb9b91b003c0f5453841941629d57f9d3bc395c75649e10dca79c0b83c8`).
+- Live host conformance: `PASS`, 14/14 baseline operations.
+  `work/release-1-19/evidence/live-host-conformance-pi.json`
+  (`sha256:9fbc54417e89b973e48e0343c6bdf76de1fd9ce13f8fa179067c13c20a107eb7`).
+- Live host receipt:
+  `work/release-1-19/evidence/live-host-receipts/pi.json`
+  (`sha256:318c5731c8e16c2ca59bca147432a989392a3660adc9bcd24aa43d0646168c7e`).
+- Live calibration: `PASS`, 14/14 scenario/cohort runs,
+  `qualityRegressionCount=0`.
+  `work/release-1-19/evidence/live-calibration-verification-pi.json`
+  (`sha256:a044ff796d79ed4efcb625261fd900126a90c21b312b5b0550d05de9d9d5df26`).
+- Live calibration receipt:
+  `work/release-1-19/evidence/live-calibration-receipts/pi.json`
+  (`sha256:dc434c31ac791ff7ccbecfb34954e23135ad97f250340898d2372ace134cac8c`).
+- Host env hygiene, harness reports: `PASS`.
+  `work/release-1-19/evidence/host-env-hygiene-pi-harness-reports.json`
+  (`sha256:93b72385e260b95b272db8ecd4c9434b12e9f0956e0167ecf3d6be6a244eb666`).
+- Host env hygiene, scanned evidence: `PASS`.
+  `work/release-1-19/evidence/host-env-hygiene-pi-all-scanned.json`
+  (`sha256:f98f64dcca61b8841d44efc6c3821b71917d3460a65a6ba39ebba59fea60e87e`).
+- ALK lifecycle final proof:
+  `work/release-1-19/evidence/pi/full-lifecycle/final/final-proof.json`
+  (`sha256:581ad5a82e5525e7bdc1bd7f7b48d301588d25497731fc4cc80e5dd70866a330`).
+
+Resource accounting:
+
+- Live conformance budget usage: 14 invocations, 6996 billable tokens,
+  58.558 wall seconds.
+- Live calibration budget usage: 14 invocations, 6708 billable tokens,
+  45.372 wall seconds.
+- Workflow final proof: `READY_FOR_FINALIZATION`, 4/4 workflow tasks accepted,
+  final proof hash
+  `581ad5a82e5525e7bdc1bd7f7b48d301588d25497731fc4cc80e5dd70866a330`.
+- Budget mode: `subscription`; USD-cost accounting is host-reported and is not
+  required for this non-metered promotion gate.
+
+Decision:
+
+Pi is promoted from `EXPERIMENTAL` to host-specific `VERIFIED` for Pi 0.83.0
+in this source tree. The decision is limited to the tested host range and
+committed evidence summary above. It does not claim public package approval,
+public directory approval, production platform promotion, ACP support, or
+sandbox containment beyond the bounded no-tools/no-session/no-context harness
+policy.

--- a/docs/adapters/install.md
+++ b/docs/adapters/install.md
@@ -271,11 +271,35 @@ documented env-key name.
 ## Pi
 
 ```bash
+pi --version
 agent-lifecycle adapter install-plan --descriptor adapters/pi/adapter.descriptor.json
 ```
 
-Pi is represented as RPC/JSON plus AGENTS/agentskills projection. Offline
-fixtures do not promote adapter maturity.
+Pi has host-specific `VERIFIED` support for Pi `0.83.0` on the tested
+host-local provider/model binding. The selected provider's credential must be
+visible to the `pi` process before a local live rerun can start. Use Pi's own
+provider documentation or config to choose the env-key name; ALK does not
+hardcode provider secret names.
+
+To scope that key to the ALK harness process, use a private operator env file
+and explicitly allow the selected provider variable:
+
+```bash
+python tools/live_hosts/pi_harness.py \
+  --mode preflight \
+  --pi-provider <provider> \
+  --pi-model <model-id> \
+  --host-env-file ~/.config/alk/hosts/pi.env \
+  --host-env-allow <PROVIDER_API_KEY_NAME> \
+  --budget-mode subscription \
+  --max-invocations 14 \
+  --max-billable-tokens <token-cap> \
+  --allow-live \
+  --report work/<release>/evidence/preflight/pi-preflight-report.json
+```
+
+The verified Pi claim does not claim ACP support, public directory approval or
+production promotion.
 
 ## Promotion boundary
 

--- a/docs/adapters/pi.md
+++ b/docs/adapters/pi.md
@@ -1,6 +1,7 @@
 # Pi Adapter
 
-The Pi projection is `EXPERIMENTAL` and uses RPC/JSON plus AGENTS/agentskills
+The Pi projection is host-specific `VERIFIED` for Pi `0.83.0` on the tested
+host-local provider/model binding. It uses RPC/JSON plus AGENTS/agentskills
 metadata. Its descriptor records the alternate protocol surface as unsupported
 by default and keeps all lifecycle semantics delegated to ALK core.
 
@@ -9,6 +10,34 @@ Tracked source artifacts:
 - `adapters/pi/adapter.descriptor.json`
 - `adapters/pi/capabilities.manifest.json`
 - `conformance/adapters/pi/offline-baseline.json`
+- `tools/live_hosts/pi_harness.py`
+- `docs/adapters/evidence/pi-live-verified.md`
 
-Promotion requires live conformance, usage receipts, resource evidence and
-accepted lifecycle proof. Offline fixtures alone do not promote this adapter.
+The verified claim is limited to the tested Pi `0.83.0` host range and does not
+claim public package approval, does not claim public directory approval,
+production promotion or ACP support. Live promotion used bounded
+no-session/no-tools/no-context invocations with explicit provider/model
+selection, redacted host-env handling, clean-worktree checks, live conformance,
+live calibration and accepted lifecycle proof.
+
+For local reruns, the selected Pi provider remains responsible for the
+credential name and source. ALK only scopes an operator-approved env file into
+the harness process:
+
+```bash
+python tools/live_hosts/pi_harness.py \
+  --mode preflight \
+  --pi-provider <provider> \
+  --pi-model <model-id> \
+  --host-env-file ~/.config/alk/hosts/pi.env \
+  --host-env-allow <PROVIDER_API_KEY_NAME> \
+  --budget-mode subscription \
+  --max-invocations 14 \
+  --max-billable-tokens <token-cap> \
+  --allow-live \
+  --report work/<release>/evidence/preflight/pi-preflight-report.json
+```
+
+Replace `<PROVIDER_API_KEY_NAME>` with the env-key name required by the
+selected provider. The value must stay outside tracked repository files and
+receipts.

--- a/docs/adapters/support-matrix.md
+++ b/docs/adapters/support-matrix.md
@@ -30,7 +30,7 @@ adapter by itself.
 | Kimi Code | Host-local projection, bounded runner, live harness and capability manifest | EXPERIMENTAL | Kimi Code 0.30.0 safe inspection and bounded harness shape passed; local live canary is blocked until a provider/model alias is configured; live receipts, usage calibration, lifecycle proof, and publication not claimed |
 | OpenCode | Root `opencode.json`, shared skills, JS adapter projection metadata, and capability manifest | VERIFIED | OpenCode CLI 1.18.9 live host conformance, live calibration, and ALK lifecycle proof passed locally; npm publication not claimed |
 | OpenInterpreter | Host-local compatible CLI projection, bounded JSONL live harness and capability manifest | VERIFIED | `interpreter` 0.0.34 live host conformance, live calibration, containment and ALK lifecycle proof passed locally on a host-local provider/model binding; public directory approval not claimed |
-| Pi | RPC/JSON plus AGENTS/agentskills projection and capability manifest | EXPERIMENTAL | Offline conformance fixtures only; live receipts, usage calibration, lifecycle proof, and publication not claimed |
+| Pi | RPC/JSON plus AGENTS/agentskills projection, bounded JSONL live harness and capability manifest | VERIFIED | Pi 0.83.0 live host conformance, live calibration, containment, host-env hygiene and ALK lifecycle proof passed locally on a host-local provider/model binding; public directory approval not claimed |
 | Qwen Code | Host-local qwen CLI runner, source projection, and capability manifest | VERIFIED | Qwen Code 0.21.0 live host conformance, live calibration, and ALK lifecycle proof passed on a host-local provider/model binding; public package approval not claimed |
 
 ## Event capture support
@@ -89,17 +89,16 @@ Hermes is `VERIFIED` for host-local model routing on Hermes Agent v0.19.0.
 Qwen Code is `VERIFIED` for host-local model routing on Qwen Code 0.21.0.
 Goose is `VERIFIED` for host-local model routing on Goose 1.45.0. Grok Build is
 `VERIFIED` for host-local model routing on Grok Build 0.2.117. OpenInterpreter
-is `VERIFIED` for host-local model routing on `interpreter` 0.0.34. The verified
-adapters' live receipts include host usage attestation, quality pass status,
-and bounded budget evidence. Cursor, Gemini CLI, Kimi Code and Pi remain
-`EXPERIMENTAL`: Cursor declares fail-closed support for host-local model
-profiles and model-route execution, Gemini CLI and Kimi Code have bounded
-runners/harnesses, and Pi has offline adapter descriptors and conformance
-fixtures. These adapters still need accepted live usage receipts,
-quality/resource evidence and a concrete live host range before a host-specific
-`VERIFIED` claim. On the current local host, Gemini CLI is blocked by an
-unsupported Gemini Code Assist client tier, and Kimi Code is blocked by missing
-provider/model configuration.
+is `VERIFIED` for host-local model routing on `interpreter` 0.0.34. Pi is
+`VERIFIED` for host-local model routing on Pi 0.83.0. The verified adapters'
+live receipts include host usage attestation, quality pass status, and bounded
+budget evidence. Cursor, Gemini CLI and Kimi Code remain `EXPERIMENTAL`: Cursor
+declares fail-closed support for host-local model profiles and model-route
+execution, while Gemini CLI and Kimi Code have bounded runners/harnesses. These
+adapters still need accepted live usage receipts, quality/resource evidence and
+a concrete live host range before a host-specific `VERIFIED` claim. On the
+current local host, Gemini CLI is blocked by an unsupported Gemini Code Assist
+client tier, and Kimi Code is blocked by missing provider/model configuration.
 Provider-flexible adapters must use the selected host/provider's configured or
 documented env-key name rather than an ALK hardcoded secret name.
 
@@ -353,6 +352,42 @@ This evidence does not claim universal adapter support, public directory
 approval, verified OS sandbox containment, or a broader production-promotion
 platform matrix pass. The containment evidence is limited to the bounded
 ephemeral read-only harness invocation policy.
+
+## Pi Live Evidence
+
+Pi is verified only for the tested local host range:
+
+- Host: Pi 0.83.0.
+- Source revision:
+  `75317878358a3dffa4b503cdb8bd8fff40de770b`.
+- Committed redacted evidence summary:
+  `docs/adapters/evidence/pi-live-verified.md`.
+- Install/source probe:
+  `work/release-1-19/evidence/pi-install-probe.json`.
+- Live preflight:
+  `work/release-1-19/evidence/preflight/pi-preflight-report-live-ready.json`.
+- Bounded containment receipt:
+  `work/release-1-19/evidence/pi-containment-receipt-live-ready.json`.
+- Live host conformance receipt:
+  `work/release-1-19/evidence/live-host-receipts/pi.json`.
+- Live host conformance validation:
+  `work/release-1-19/evidence/live-host-conformance-pi.json`.
+- Live calibration receipt:
+  `work/release-1-19/evidence/live-calibration-receipts/pi.json`.
+- Live calibration validation:
+  `work/release-1-19/evidence/live-calibration-verification-pi.json`.
+- Host env hygiene:
+  `work/release-1-19/evidence/host-env-hygiene-pi-harness-reports.json`.
+- Host env hygiene scanned evidence:
+  `work/release-1-19/evidence/host-env-hygiene-pi-all-scanned.json`.
+- ALK lifecycle final proof:
+  `work/release-1-19/evidence/pi/full-lifecycle/final/final-proof.json`.
+
+This evidence does not claim universal adapter support, public directory
+approval, ACP support, verified OS sandbox containment, or a broader
+production-promotion platform matrix pass. The containment evidence is limited
+to the bounded no-tools/no-session/no project-context harness invocation
+policy.
 
 ## Neutrality error contract
 

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -123,7 +123,7 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
 | Kimi Code | `EXPERIMENTAL`; для проверки нужен настроенный провайдер и псевдоним модели. |
 | Grok Build | `VERIFIED` для Grok Build 0.2.117 на проверенной host-local provider/model связке. Одобрение публичного каталога не заявлено. |
 | OpenInterpreter | `VERIFIED` для `interpreter` 0.0.34 на проверенной host-local provider/model связке. Одобрение публичного каталога не заявлено. |
-| Pi | `EXPERIMENTAL`; RPC/JSON и AGENTS/agentskills projection без заявления о live promotion. |
+| Pi | `VERIFIED` для Pi 0.83.0 на проверенной host-local provider/model связке. Одобрение публичного каталога не заявлено. |
 
 Подробнее: [Установка адаптеров](adapters/install.md) и
 [матрица поддержки адаптеров](adapters/support-matrix.md).

--- a/docs/ru/adapters/install.md
+++ b/docs/ru/adapters/install.md
@@ -158,11 +158,34 @@ python tools/live_hosts/openinterpreter_harness.py \
 ## Pi
 
 ```bash
+pi --version
 agent-lifecycle adapter install-plan --descriptor adapters/pi/adapter.descriptor.json
 ```
 
-Pi описан как RPC/JSON и AGENTS/agentskills projection. Offline fixtures не
-повышают зрелость адаптера.
+Pi имеет host-specific `VERIFIED` для Pi `0.83.0` на проверенной host-local
+provider/model связке. Учётные данные выбранного provider должны быть видны
+процессу `pi` перед локальным live rerun. Имя env-key берётся из документации
+или конфигурации выбранного Pi provider; ALK не хардкодит provider secret names.
+
+Чтобы дать ключ только ALK harness-процессу, используй приватный operator
+env-file и явно разреши переменную выбранного provider:
+
+```bash
+python tools/live_hosts/pi_harness.py \
+  --mode preflight \
+  --pi-provider <provider> \
+  --pi-model <model-id> \
+  --host-env-file ~/.config/alk/hosts/pi.env \
+  --host-env-allow <PROVIDER_API_KEY_NAME> \
+  --budget-mode subscription \
+  --max-invocations 14 \
+  --max-billable-tokens <token-cap> \
+  --allow-live \
+  --report work/<release>/evidence/preflight/pi-preflight-report.json
+```
+
+Проверенный Pi claim не заявляет ACP support, public directory approval или
+production promotion.
 
 ## Граница продвижения
 

--- a/docs/ru/adapters/support-matrix.md
+++ b/docs/ru/adapters/support-matrix.md
@@ -17,7 +17,7 @@
 | Kimi Code | `EXPERIMENTAL` | Нужен настроенный провайдер и алиас модели. |
 | Grok Build | `VERIFIED` | Проверен для Grok Build 0.2.117 на host-local provider/model связке; public directory approval не заявлен. |
 | OpenInterpreter | `VERIFIED` | Проверен для `interpreter` 0.0.34 на host-local provider/model связке; live conformance, calibration, containment и lifecycle proof прошли локально, public directory approval не заявлен. |
-| Pi | `EXPERIMENTAL` | RPC/JSON и AGENTS/agentskills projection без live promotion. |
+| Pi | `VERIFIED` | Проверен для Pi 0.83.0 на host-local provider/model связке; live conformance, calibration, containment, host-env hygiene и lifecycle proof прошли локально, public directory approval не заявлен. |
 
 `VERIFIED` относится только к указанному диапазону хоста и не означает
 публичное одобрение каталога, npm-публикацию или готовность других версий.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-lifecycle-kit"
-version = "1.18.0"
+version = "1.19.0"
 description = "Provider-neutral lifecycle controller core for specification, planning, execution, validation, and audit workflows."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/release/candidate/inventory.json
+++ b/release/candidate/inventory.json
@@ -36,32 +36,32 @@
   "files": [
     {
       "path": ".agents/plugins/marketplace.json",
-      "sha256": "ea823a1040d3b029bc89e2600e84d9a2c19a75fadf432c970b37ff7578d376b1",
+      "sha256": "bd74b10328d4eaa3232482b6689c13ccda63ba2edf64eae71605243084dbcdff",
       "bytes": 448
     },
     {
       "path": ".claude-plugin/marketplace.json",
-      "sha256": "7a19d47fb096f7299c0986b182b0c674a6f12794a3461cc4f9dd5406f170f7f8",
+      "sha256": "856a3eb9883fccf868a7804db20468f48363f1c832977837359ed39498703a72",
       "bytes": 838
     },
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "6da6a3812b146ab69b480341850d2d233464e17280b69f6d72ba83d4d5772f7e",
+      "sha256": "19f85eed9f936e3c7548a95d55e8f2ecce21a39b4571a62415404bc1723bd2c6",
       "bytes": 698
     },
     {
       "path": ".codex-plugin/plugin.json",
-      "sha256": "e7f57a11757439a10d9b433884b155b63de2848b1d5966aafab25dfa2a5467d7",
+      "sha256": "11793b4f11d512e28f01b35ef270e904f5b48ea6326a3b7d9e572aa1b46b0590",
       "bytes": 1378
     },
     {
       "path": ".cursor-plugin/marketplace.json",
-      "sha256": "569caa606d4d97ed526f7b6fc753f1675284b27ca2e0b705e33305e8aad64c23",
+      "sha256": "665117728cbf257d73ef859c00aeae7212cda6e8309afb4454c002efc49f72dc",
       "bytes": 941
     },
     {
       "path": ".cursor-plugin/plugin.json",
-      "sha256": "c2f24d9e7056ee4c186bd4b2a44dbb5f4ebd45a349faf5f0f482ebd837f6d531",
+      "sha256": "9b7b2a1d78294dafe3dfe14a612f342d9ad63fe663731497c9b48ea346738f4f",
       "bytes": 788
     },
     {
@@ -86,8 +86,8 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "41cdfff88d4eb905bd16ff752f1e189e319f514471d42d6be943788f013f4831",
-      "bytes": 20163
+      "sha256": "21fcfe4b0ab2e87ec1961ab45d015ad26ea34e521589fba7d21ce1d8a297c9c1",
+      "bytes": 20649
     },
     {
       "path": "CONTRIBUTING.md",
@@ -106,8 +106,8 @@
     },
     {
       "path": "README.md",
-      "sha256": "0068f746a2a933cc1cfa4dde48720c610d24fe69323e8515bebc392a98cd58fe",
-      "bytes": 8558
+      "sha256": "2884e1dc1a372938b0cb77077ff911023bac20ff6c453eacd572aba2802288cd",
+      "bytes": 8585
     },
     {
       "path": "SECURITY.md",
@@ -121,7 +121,7 @@
     },
     {
       "path": "adapters/claude/.claude-plugin/plugin.json",
-      "sha256": "3ecf54ad448f17bf0d8f413f34e78872fe41add72202ea4e4613103f4d8208e7",
+      "sha256": "059fb7f29d72df5965bb1fd851d9e5bfd13000dd1dd0f6c96754b14f89aedeac",
       "bytes": 562
     },
     {
@@ -141,7 +141,7 @@
     },
     {
       "path": "adapters/codex/.codex-plugin/plugin.json",
-      "sha256": "fff814622050f65168657d48b4aeef38456d2e7d6b842c071548e5ff6fa2e25a",
+      "sha256": "a7f28175f1e73d67eb78355aa8b950c45dbcea11c41cee5ee9183e794c7ed0dc",
       "bytes": 1181
     },
     {
@@ -161,7 +161,7 @@
     },
     {
       "path": "adapters/cursor/.cursor-plugin/plugin.json",
-      "sha256": "01a3a6cb387728ef20a29ef979cc3e05fb896a356f35c8a0c4da08864a44c534",
+      "sha256": "8d8f40b3048861e0d4e946f5300484c26b200508d09ca49f2ae27bc113e87657",
       "bytes": 538
     },
     {
@@ -346,18 +346,18 @@
     },
     {
       "path": "adapters/pi/README.md",
-      "sha256": "b5f2149b2964bd2749b51f987836931b52fd945359e2eaae013a4f6204ea5cea",
-      "bytes": 362
+      "sha256": "112e42c48ac260b4f1a30faef095a0b6e3161ede8d1934ee2107718a1e6f978b",
+      "bytes": 646
     },
     {
       "path": "adapters/pi/adapter.descriptor.json",
-      "sha256": "959ad4ec062225bc27be2eb57c3e9912c8c77465b07bef20210de7b51cef1df5",
-      "bytes": 4867
+      "sha256": "5313149cf0ed39319e19b00b1d2b42e0d2fa346591018a38854f85c9174ec09d",
+      "bytes": 5917
     },
     {
       "path": "adapters/pi/capabilities.manifest.json",
-      "sha256": "67385c7c6885aee1dc53233215d0476f2d3459ca5c1c544d0eef7524c1b496fd",
-      "bytes": 7417
+      "sha256": "eb8024a62cada234dcdbfb6c2567040d7be3f43f21f8c8a5db50a150a85c2f0f",
+      "bytes": 8542
     },
     {
       "path": "adapters/qwen-code/adapter.descriptor.json",
@@ -561,7 +561,7 @@
     },
     {
       "path": "conformance/adapters/pi/event-stream-receipt.json",
-      "sha256": "f46f7b831eaf20a870dd94b6f7263e4e09d24119c61f63b6f27700206a93e353",
+      "sha256": "36c6d1081fbdebe4f5381b95c22ae167537704f27e5ee239f2a1a0d3c9c089a2",
       "bytes": 943
     },
     {
@@ -601,8 +601,8 @@
     },
     {
       "path": "conformance/core/live-calibration-profile.v1.json",
-      "sha256": "6ebe4ed92601010aece161dd429714b203386c9637dd44eeddce87e9a48b9ebd",
-      "bytes": 1095
+      "sha256": "eabdd00604cf5a35a025b0a17f55e920a47e54403da8e46c85c2664c6472bef9",
+      "bytes": 1105
     },
     {
       "path": "conformance/core/scenario-taxonomy.v1.json",
@@ -641,8 +641,8 @@
     },
     {
       "path": "docs/adapters/evidence/adapter-evidence-summary.v1.json",
-      "sha256": "aefb541f44f3feaab4988770a6142b81563dc146ea65810de86e4f1605779c0d",
-      "bytes": 5753
+      "sha256": "59c8d1468d682e0e89581cecbdbd4f1bd87e6e5b5d277728e666b2c1b9f58deb",
+      "bytes": 5823
     },
     {
       "path": "docs/adapters/evidence/claude-code-0.5.0.md",
@@ -725,6 +725,11 @@
       "bytes": 859
     },
     {
+      "path": "docs/adapters/evidence/pi-live-verified.md",
+      "sha256": "f6056a02b4922c69019c4c6849f474b9e6697355744ee66705aba7a4847a8d22",
+      "bytes": 3293
+    },
+    {
       "path": "docs/adapters/evidence/qwen-code-0.11.0.md",
       "sha256": "b0a55a26648e1ad93739d77455d86594b6165886472dabd6dd394f5dcd87bd2f",
       "bytes": 2613
@@ -761,8 +766,8 @@
     },
     {
       "path": "docs/adapters/install.md",
-      "sha256": "e5ff608fc1e8a160b83b1d7a1c3cff17ebc9818eb86f1e723061d7a8eaf2fb9c",
-      "bytes": 8205
+      "sha256": "c8b01f92fb9b452389d9bf98336229ce74a776ecce5fd6eb79a0bf550204da01",
+      "bytes": 9070
     },
     {
       "path": "docs/adapters/kimi-code.md",
@@ -791,8 +796,8 @@
     },
     {
       "path": "docs/adapters/pi.md",
-      "sha256": "bdcb06d77ed491b59a5a05faa7e0d2e143edddcda01814ba5a9461acf3a4921d",
-      "bytes": 554
+      "sha256": "8dca7eaaf7f62cf6ad256ae1e11088ca1ca4fe50698a266a267ea51b3df84551",
+      "bytes": 1707
     },
     {
       "path": "docs/adapters/qwen-code.md",
@@ -806,8 +811,8 @@
     },
     {
       "path": "docs/adapters/support-matrix.md",
-      "sha256": "b6dbc10c63e3e42c7ec9fd6852f0636fa548119f08bb5cae42ad1e9a07c8c44c",
-      "bytes": 21782
+      "sha256": "d31b3516599b39ce9a88da5b5aeff16d4751351ff9f33925f771ea5da9597e1b",
+      "bytes": 23399
     },
     {
       "path": "docs/architecture/modular-controller.md",
@@ -1021,18 +1026,18 @@
     },
     {
       "path": "docs/ru/README.md",
-      "sha256": "3c1b3036df636c5a637b187258d35aa8da23987bc3e18d531135a8ef87753e2d",
-      "bytes": 13053
+      "sha256": "24f2462ac16ff0b765c245e7668a8aca2b62b1dcbdc52c71e55018c7e506f688",
+      "bytes": 13126
     },
     {
       "path": "docs/ru/adapters/install.md",
-      "sha256": "b98db72a928e2ce21ff970a48d891689a659bff058a7f7db1b27d8d170ba8fb6",
-      "bytes": 7031
+      "sha256": "c4b87266d9a6edf2b7d7dfeb1ee575f0033b647fce330e578286efed23f7a627",
+      "bytes": 8095
     },
     {
       "path": "docs/ru/adapters/support-matrix.md",
-      "sha256": "4cf7973e81de2a11e6e103bd81e6df7030ec2d4b0bf2cee7164f40c573e23b80",
-      "bytes": 2237
+      "sha256": "0e1952e62dde3754384ad7c47d7945425da54dea2f4da899b562bbe937162073",
+      "bytes": 2405
     },
     {
       "path": "docs/ru/quickstart.md",
@@ -1221,7 +1226,7 @@
     },
     {
       "path": "pyproject.toml",
-      "sha256": "ad502f494e7ad4ed5216c71bf458c0d217a4f1bf1eba74211fb789af554b3adc",
+      "sha256": "f910b2b5fea95b1cb608776ac9a4d28b1f6695687fefd4e0a591a241576b1a67",
       "bytes": 1134
     },
     {
@@ -1271,7 +1276,7 @@
     },
     {
       "path": "src/agent_lifecycle/_version.py",
-      "sha256": "d2a4ad49ca1fac1e71e6951ce8ae2d93631723c85f42b692bb04cad0edbed943",
+      "sha256": "d16b44e2e50a7a199c3e686c195d46b2aba18877a0e69d098aa32ad8fe355bb4",
       "bytes": 47
     },
     {
@@ -2131,8 +2136,8 @@
     },
     {
       "path": "tests/adapters/test_host_adapters.py",
-      "sha256": "9079f44e135a3c1da753db443125ac113ca6a10a88da55ba58312ddeb2b3376c",
-      "bytes": 12363
+      "sha256": "176ccca1a92eb78de8b006777e34801157b956a5362d62b7bfad378c75d1415c",
+      "bytes": 12395
     },
     {
       "path": "tests/adapters/test_host_protocol_inspection.py",
@@ -2156,7 +2161,7 @@
     },
     {
       "path": "tests/adapters/test_publication_manifests.py",
-      "sha256": "68a282727402c6a34956444c3d539e5489ea88e705dab984148d22466ba2b942",
+      "sha256": "c7e8678a6caebc4e79ce31e7222afadccfec63051a0333d52af5d0e1ce6f2764",
       "bytes": 7073
     },
     {
@@ -2511,8 +2516,8 @@
     },
     {
       "path": "tests/live_hosts/test_common_budget.py",
-      "sha256": "caf2359334c8a746c8ba303453fa6591b4a71a16183393f49fffad619465ef2c",
-      "bytes": 8743
+      "sha256": "3fbf7b62a45e3440dd6a6fd896e9892f04bc8b6deb57c8c17994d5653cacfdda",
+      "bytes": 8783
     },
     {
       "path": "tests/live_hosts/test_cursor_harness.py",
@@ -2555,14 +2560,19 @@
       "bytes": 9577
     },
     {
+      "path": "tests/live_hosts/test_pi_adapter.py",
+      "sha256": "36f79dfe4ddf383ce831f8984beb19ac363394b4f9fc65c429ac280fd6458ba4",
+      "bytes": 10376
+    },
+    {
       "path": "tests/live_hosts/test_qwen_code_harness.py",
       "sha256": "c2b2a1b5cf940d2e26f39cd0353a95380cfc4db3b0dc99cea734f5c3ec9f421d",
       "bytes": 9532
     },
     {
       "path": "tests/live_hosts/test_secondary_adapters.py",
-      "sha256": "fe0763aa6349badee2be44da8f4e58c8779ba2e3b0334d0f2aa16082930d8d32",
-      "bytes": 1604
+      "sha256": "bb488830bf89b961994be2b7b9aab1075fd7eb3810b6acf8dd4f33ee1f9c038f",
+      "bytes": 2239
     },
     {
       "path": "tests/metrics/__init__.py",
@@ -2671,7 +2681,7 @@
     },
     {
       "path": "tests/package/test_foundation.py",
-      "sha256": "524398bfdbc4f3fc76e583157c142d7afeb7527c1ead267e1178efa6588d52ea",
+      "sha256": "cb1894dc4a726359177c8eab949a395a1aec217b15b5f9dfc1a92b8c6fd56931",
       "bytes": 7804
     },
     {
@@ -2776,8 +2786,8 @@
     },
     {
       "path": "tests/release/test_release_inventory.py",
-      "sha256": "ddc6d0d90985d3c00ada6efe9560944ced57f12862a419c007e92c8fbc9bfcc7",
-      "bytes": 6942
+      "sha256": "f2ef2de2daf8043e60f2a5cd82d558571583124ba5e0f2ae933a235371cb82db",
+      "bytes": 7063
     },
     {
       "path": "tests/release/test_task_packet_context.py",
@@ -2985,6 +2995,16 @@
       "bytes": 23069
     },
     {
+      "path": "tools/live_hosts/pi_harness.py",
+      "sha256": "86af1ab7ae33084687a4c20740f6f6fc31d4a2d77922175915d3d63d9b622a74",
+      "bytes": 22631
+    },
+    {
+      "path": "tools/live_hosts/pi_install_probe.py",
+      "sha256": "470ead530653ef08cc6ed75c6b0b1d4de013b6368ea16e59c572a36e5920f754",
+      "bytes": 4114
+    },
+    {
       "path": "tools/live_hosts/qwen_code_harness.py",
       "sha256": "09604b5eaadcba73f64f44693fc6316916e8dd3c5fb23b6e911e110fe6b0f7d6",
       "bytes": 43570
@@ -3011,8 +3031,8 @@
     },
     {
       "path": "tools/release/validate_docs_compat.py",
-      "sha256": "92b8451d76d824e86c630381c38a0c48316684aef981a24f8241e83f264b8f45",
-      "bytes": 18299
+      "sha256": "51bb6d877d55ea4e38e5669f738120020ade7503362cd2aa45e59391cecc40cc",
+      "bytes": 18507
     },
     {
       "path": "tools/release/validate_host_env_hygiene.py",
@@ -3066,9 +3086,9 @@
     },
     {
       "path": "uv.lock",
-      "sha256": "9f43757994f894a2baf2440eb3a5f83b9a2f0f389b8524c5fc60e9a24965e000",
+      "sha256": "02aa6d0ad445989d5ac0a8bd302f8adcb8f92e8f522e7e922f5d175d1de3e2f5",
       "bytes": 186
     }
   ],
-  "candidatePayloadInventoryDigest": "5943d2d519e19ebc6f9271588a855f9c473d10030af7845469ba66000d735603"
+  "candidatePayloadInventoryDigest": "d2f904a359e3a3300a83ac6a84a6c9322a1490bd8a6580d18ea1337600401728"
 }

--- a/src/agent_lifecycle/_version.py
+++ b/src/agent_lifecycle/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.18.0"
+__version__ = "1.19.0"

--- a/tests/adapters/test_host_adapters.py
+++ b/tests/adapters/test_host_adapters.py
@@ -82,6 +82,7 @@ HOSTS = {
         "secondary": True,
         "nativeProjection": "rpc-json-skills",
         "modelRouting": True,
+        "maturity": "VERIFIED",
         "hostCapability": "unsupported-alt-protocol",
     },
     "qwen-code": {

--- a/tests/adapters/test_publication_manifests.py
+++ b/tests/adapters/test_publication_manifests.py
@@ -8,7 +8,7 @@ from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "1.18.0"
+VERSION = "1.19.0"
 PLUGIN_NAME = "agent-lifecycle-kit"
 SKILL_NAMES = {
     "agent-first-planning",

--- a/tests/live_hosts/test_common_budget.py
+++ b/tests/live_hosts/test_common_budget.py
@@ -21,6 +21,7 @@ from tools.live_hosts import (  # noqa: E402
     kimi_code_harness,
     opencode_harness,
     openinterpreter_harness,
+    pi_harness,
     qwen_code_harness,
 )
 from tools.live_hosts.common import (  # noqa: E402
@@ -159,6 +160,7 @@ class HostEnvFileTests(unittest.TestCase):
             kimi_code_harness,
             opencode_harness,
             openinterpreter_harness,
+            pi_harness,
             qwen_code_harness,
         ]
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/live_hosts/test_pi_adapter.py
+++ b/tests/live_hosts/test_pi_adapter.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from agent_lifecycle.host_protocol import HostOperationReceipt, HostOperationRequest  # noqa: E402
+from tools.live_hosts import pi_harness  # noqa: E402
+
+
+class PiHarnessTests(unittest.TestCase):
+    def test_fixture_operations_cover_adapter_baseline_with_valid_envelopes(self) -> None:
+        baseline = _load_json(ROOT / "conformance/core/adapter-baseline.v1.json")
+
+        operations = pi_harness.build_fixture_operations("pi", baseline)
+
+        self.assertEqual({operation["name"] for operation in operations}, set(baseline["requiredOperations"]))
+        for operation in operations:
+            request = HostOperationRequest.from_json(operation["hostOperationRequest"])
+            receipt = HostOperationReceipt.from_json(operation["hostOperationReceipt"])
+            self.assertEqual(request.operation_id, receipt.operation_id)
+            self.assertEqual(request.capability, operation["name"])
+
+    def test_parser_uses_last_nonzero_nested_pi_usage(self) -> None:
+        payload = "\n".join(
+            [
+                json.dumps({"type": "session", "id": "session-1"}),
+                json.dumps({"type": "message_update", "message": {"usage": {"input": 0, "output": 0, "totalTokens": 0}}}),
+                json.dumps(
+                    {
+                        "type": "message_end",
+                        "message": {
+                            "usage": {
+                                "input": 12,
+                                "output": 37,
+                                "cacheRead": 384,
+                                "cacheWrite": 0,
+                                "reasoning": 30,
+                                "totalTokens": 433,
+                                "cost": {"total": 0},
+                            }
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [
+                            {},
+                            {
+                                "usage": {
+                                    "input": 14,
+                                    "output": 39,
+                                    "cacheRead": 390,
+                                    "cacheWrite": 0,
+                                    "totalTokens": 443,
+                                    "cost": {"total": 0},
+                                }
+                            },
+                        ],
+                    }
+                ),
+            ]
+        )
+
+        usage = pi_harness.parse_pi_jsonl(payload, wall_seconds=1.234)
+
+        self.assertEqual(usage.session_id, "session-1")
+        self.assertEqual(usage.input_tokens, 14)
+        self.assertEqual(usage.output_tokens, 39)
+        self.assertEqual(usage.billable_tokens, 443)
+        self.assertEqual(usage.cost_usd, None)
+        self.assertEqual(usage.wall_seconds, 1.234)
+
+    def test_containment_blocks_missing_explicit_provider_and_model(self) -> None:
+        blockers = pi_harness._containment_blockers(
+            pi_provider=None,
+            pi_model=None,
+            pi_thinking=None,
+            model_selection=None,
+        )
+
+        self.assertIn("BLOCKED_MODEL_BINDING_UNDECLARED", {item["code"] for item in blockers})
+
+    def test_operation_command_is_bounded_json_print(self) -> None:
+        command = pi_harness._operation_command(
+            "pi",
+            "discover",
+            pi_provider="provider",
+            pi_model="model-id",
+            pi_thinking="off",
+            model_selection=None,
+        )
+
+        self.assertEqual(command[:3], ["pi", "--mode", "json"])
+        self.assertIn("--no-session", command)
+        self.assertIn("--no-tools", command)
+        self.assertIn("--no-extensions", command)
+        self.assertIn("--no-skills", command)
+        self.assertIn("--no-context-files", command)
+        self.assertIn("--no-approve", command)
+        self.assertIn("--offline", command)
+        self.assertEqual(command[command.index("--provider") + 1], "provider")
+        self.assertEqual(command[command.index("--model") + 1], "model-id")
+        self.assertEqual(command[command.index("--thinking") + 1], "off")
+        self.assertIn("--print", command)
+
+    def test_live_host_receipt_with_fake_runner_writes_validator_compatible_receipt(self) -> None:
+        baseline = _load_json(ROOT / "conformance/core/adapter-baseline.v1.json")
+        calls: list[list[str]] = []
+
+        def fake_runner(command: list[str]) -> pi_harness.CommandResult:
+            calls.append(command)
+            operation = command[-1].split("Operation: ", 1)[1].split(".", 1)[0]
+            stdout = "\n".join(
+                [
+                    json.dumps({"type": "session", "id": f"session-{operation}"}),
+                    json.dumps({"type": "message_end", "message": {"usage": {"input": 10, "output": 5, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 15}}}),
+                ]
+            )
+            return pi_harness.CommandResult(returncode=0, stdout=stdout, stderr="", wall_seconds=0.1)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            receipt_dir = tmp_path / "receipts"
+            receipt = receipt_dir / "pi.json"
+            report = pi_harness.run_live_host_receipt(
+                pi_bin="pi",
+                baseline_path=ROOT / "conformance/core/adapter-baseline.v1.json",
+                worktree=tmp_path / "clean-worktree",
+                allow_live=True,
+                receipt_path=receipt,
+                diagnostic_dir=tmp_path / "diagnostics",
+                budget_policy=pi_harness.BudgetPolicy(
+                    mode="subscription",
+                    max_invocations=len(baseline["requiredOperations"]),
+                    max_billable_tokens=1000,
+                ),
+                pi_provider="provider",
+                pi_model="model-id",
+                runner=fake_runner,
+                clean_worktree_checker=lambda _: {"clean": True, "dirtyEntryCount": 0},
+            )
+
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(report["status"], "PASS")
+            self.assertEqual(payload["schemaVersion"], pi_harness.LIVE_HOST_RECEIPT_SCHEMA)
+            self.assertEqual(payload["host"], "pi")
+            self.assertFalse(payload["syntheticReplayUsed"])
+            self.assertTrue(payload["usageAttested"])
+            self.assertEqual({item["name"] for item in payload["operations"]}, set(baseline["requiredOperations"]))
+            self.assertEqual(len(calls), len(baseline["requiredOperations"]))
+
+            validation_evidence = tmp_path / "host-conformance-validation.json"
+            validation = subprocess.run(
+                [
+                    sys.executable,
+                    "tools/release/validate_live_host_conformance.py",
+                    "--profile",
+                    "conformance/core/live-calibration-profile.v1.json",
+                    "--baseline",
+                    "conformance/core/adapter-baseline.v1.json",
+                    "--receipt-dir",
+                    str(receipt_dir),
+                    "--promoted-hosts",
+                    "pi",
+                    "--evidence",
+                    str(validation_evidence),
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(validation.returncode, 0, validation.stderr)
+
+    def test_live_calibration_uses_context_byte_proxy_when_usage_omits_it(self) -> None:
+        profile = _load_json(ROOT / "conformance/core/live-calibration-profile.v1.json")
+        expected_runs = len(profile["requiredScenarios"]) * len(profile["requiredCohorts"])
+
+        def fake_runner(command: list[str]) -> pi_harness.CommandResult:
+            stdout = "\n".join(
+                [
+                    json.dumps({"type": "session", "id": "session-proxy"}),
+                    json.dumps({"type": "message_end", "message": {"usage": {"input": 10, "output": 5, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 15}}}),
+                ]
+            )
+            return pi_harness.CommandResult(returncode=0, stdout=stdout, stderr="", wall_seconds=0.1)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            receipt = tmp_path / "calibration/pi.json"
+            report = pi_harness.run_live_calibration(
+                pi_bin="pi",
+                profile_path=ROOT / "conformance/core/live-calibration-profile.v1.json",
+                budget_targets_path=ROOT / "conformance/core/budget-targets.v1.json",
+                worktree=tmp_path / "clean-worktree",
+                runs_per_scenario_cohort=1,
+                allow_live=True,
+                receipt_path=receipt,
+                diagnostic_dir=tmp_path / "diagnostics",
+                budget_policy=pi_harness.BudgetPolicy(
+                    mode="subscription",
+                    max_invocations=expected_runs,
+                    max_billable_tokens=expected_runs * 20,
+                ),
+                pi_provider="provider",
+                pi_model="model-id",
+                runner=fake_runner,
+                clean_worktree_checker=lambda _: {"clean": True, "dirtyEntryCount": 0},
+            )
+
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(report["status"], "PASS")
+            self.assertEqual(payload["host"], "pi")
+            self.assertEqual(payload["liveModelInvocations"], expected_runs)
+            first_usage = payload["runs"][0]["usage"]
+            self.assertGreater(first_usage["cumulativeContextBytes"], 0)
+            self.assertEqual(first_usage["cumulativeContextBytesSource"], "harness-observed-prompt-and-json-output-bytes")
+
+
+def _load_json(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError(f"expected object: {path}")
+    return value

--- a/tests/live_hosts/test_secondary_adapters.py
+++ b/tests/live_hosts/test_secondary_adapters.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-EXPERIMENTAL_SECONDARY = ("pi",)
+EXPERIMENTAL_SECONDARY: tuple[str, ...] = ()
 
 
 def test_secondary_adapters_are_experimental_without_live_range() -> None:
@@ -27,6 +27,18 @@ def test_openinterpreter_secondary_adapter_is_verified_with_live_range() -> None
     assert descriptor["modelRouting"]["liveVerified"] is True
     assert descriptor["liveTestedHostRange"]["host"] == "openinterpreter"
     assert "docs/adapters/evidence/openinterpreter-live-verified.md" in descriptor["liveTestedHostRange"]["evidence"]
+    assert conformance["liveRuntimeRequired"] is False
+    assert conformance["requiredMaturity"] == "EXPERIMENTAL"
+
+
+def test_pi_secondary_adapter_is_verified_with_live_range() -> None:
+    descriptor = _load_json(ROOT / "adapters/pi/adapter.descriptor.json")
+    conformance = _load_json(ROOT / "conformance/adapters/pi/offline-baseline.json")
+
+    assert descriptor["maturity"] == "VERIFIED"
+    assert descriptor["modelRouting"]["liveVerified"] is True
+    assert descriptor["liveTestedHostRange"]["host"] == "pi"
+    assert "docs/adapters/evidence/pi-live-verified.md" in descriptor["liveTestedHostRange"]["evidence"]
     assert conformance["liveRuntimeRequired"] is False
     assert conformance["requiredMaturity"] == "EXPERIMENTAL"
 

--- a/tests/package/test_foundation.py
+++ b/tests/package/test_foundation.py
@@ -18,7 +18,7 @@ class FoundationTests(unittest.TestCase):
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         project = pyproject["project"]
         self.assertEqual(project["name"], "agent-lifecycle-kit")
-        self.assertEqual(project["version"], "1.18.0")
+        self.assertEqual(project["version"], "1.19.0")
         self.assertEqual(project["requires-python"], ">=3.11,<3.14")
         self.assertEqual(project["license"]["text"], "Apache-2.0")
         self.assertEqual(project["dependencies"], [])
@@ -62,7 +62,7 @@ class FoundationTests(unittest.TestCase):
         self.assertEqual(lock["requires-python"], ">=3.11,<3.14")
         packages = {package["name"]: package for package in lock["package"]}
         self.assertIn("agent-lifecycle-kit", packages)
-        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.18.0")
+        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.19.0")
 
     def test_foundation_ci_uses_stdlib_unittest(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/tests/release/test_release_inventory.py
+++ b/tests/release/test_release_inventory.py
@@ -35,6 +35,7 @@ class ReleaseInventoryTests(unittest.TestCase):
             self.assertIn("tools/live_hosts/hermes_harness.py", {item["path"] for item in inventory_payload["files"]})
             self.assertIn("tools/live_hosts/kimi_code_harness.py", {item["path"] for item in inventory_payload["files"]})
             self.assertIn("tools/live_hosts/opencode_harness.py", {item["path"] for item in inventory_payload["files"]})
+            self.assertIn("tools/live_hosts/pi_harness.py", {item["path"] for item in inventory_payload["files"]})
             self.assertIn("tools/live_hosts/qwen_code_harness.py", {item["path"] for item in inventory_payload["files"]})
             self.assertIn("fixtures/synthetic/negative-matrix-01.json", {item["path"] for item in inventory_payload["files"]})
             self.assertIn("evals/synthetic/cost-baseline.v1.json", {item["path"] for item in inventory_payload["files"]})
@@ -74,7 +75,7 @@ class ReleaseInventoryTests(unittest.TestCase):
             self.assertEqual(matrix["adapterMaturityByHost"]["Grok Build"], "VERIFIED")
             self.assertEqual(
                 set(matrix["verifiedHosts"]),
-                {"Codex", "Claude Code", "Goose", "Grok Build", "OpenCode", "Hermes", "OpenInterpreter", "Qwen Code"},
+                {"Codex", "Claude Code", "Goose", "Grok Build", "OpenCode", "Hermes", "OpenInterpreter", "Pi", "Qwen Code"},
             )
             self.assertTrue(deferred["deferredProductionPromotion"])
             self.assertFalse(deferred["liveModelExecutionClaimed"])

--- a/tools/live_hosts/pi_harness.py
+++ b/tools/live_hosts/pi_harness.py
@@ -1,0 +1,548 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agent_lifecycle.contracts import canonical_digest  # noqa: E402
+from tools.live_hosts.common import (  # noqa: E402
+    BudgetPolicy,
+    CommandResult,
+    HarnessError,
+    HostModelSelection,
+    add_host_env_args,
+    dispatch_with_host_env,
+    load_host_model_selection,
+)
+from tools.live_hosts.json_cli_harness import (  # noqa: E402
+    LIVE_CALIBRATION_RECEIPT_SCHEMA,
+    LIVE_HOST_RECEIPT_SCHEMA,
+    JsonCliUsage,
+    base_report,
+    build_fixture_operations,
+    file_identity,
+    first_line,
+    load_json,
+    parse_jsonl_objects,
+    run_command,
+    run_fixture_check as run_json_fixture_check,
+    run_live_calibration as run_json_live_calibration,
+    run_live_host_receipt as run_json_live_host_receipt,
+    write_json,
+)
+
+
+HOST = "pi"
+HARNESS_REPORT_SCHEMA = "agent-pi-live-harness-report.v1"
+DIAGNOSTIC_SCHEMA = "agent-pi-live-invocation-diagnostic.v1"
+DEFAULT_BASELINE = Path("conformance/core/adapter-baseline.v1.json")
+DEFAULT_PROFILE = Path("conformance/core/live-calibration-profile.v1.json")
+DEFAULT_BUDGET_TARGETS = Path("conformance/core/budget-targets.v1.json")
+PiUsage = JsonCliUsage
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["preflight", "fixture-check", "live-host-receipt", "live-calibration"], required=True)
+    parser.add_argument("--baseline", default=DEFAULT_BASELINE.as_posix())
+    parser.add_argument("--profile", default=DEFAULT_PROFILE.as_posix())
+    parser.add_argument("--budget-targets", default=DEFAULT_BUDGET_TARGETS.as_posix())
+    parser.add_argument("--pi-bin", default="pi")
+    parser.add_argument("--pi-provider")
+    parser.add_argument("--pi-model")
+    parser.add_argument("--pi-thinking")
+    parser.add_argument("--host-model-profile")
+    parser.add_argument("--model-class")
+    parser.add_argument("--model-binding")
+    parser.add_argument("--model-selection-receipt")
+    add_host_env_args(parser)
+    parser.add_argument("--worktree")
+    parser.add_argument("--budget-mode", choices=["metered", "subscription", "local"], default="metered")
+    parser.add_argument("--budget-cap-usd", type=float)
+    parser.add_argument("--max-invocations", type=int)
+    parser.add_argument("--max-billable-tokens", type=int)
+    parser.add_argument("--max-wall-seconds", type=float)
+    parser.add_argument("--invocation-timeout-seconds", type=float, default=600.0)
+    parser.add_argument("--runs-per-scenario-cohort", type=int)
+    parser.add_argument("--allow-live", action="store_true")
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--receipt")
+    parser.add_argument("--containment-receipt")
+    parser.add_argument("--diagnostic-dir", default="work/release-1-19/evidence/live-host-diagnostics/pi")
+    args = parser.parse_args(argv)
+
+    try:
+        report = dispatch_with_host_env(args, _dispatch)
+    except HarnessError as error:
+        report = base_report(HARNESS_REPORT_SCHEMA, "FAIL", HOST, [{"code": error.code, "message": error.message}])
+    write_json(Path(args.report), report)
+    return 0 if report.get("status") == "PASS" else 1
+
+
+def _dispatch(args: argparse.Namespace) -> dict[str, Any]:
+    budget_policy = BudgetPolicy(
+        mode=args.budget_mode,
+        budget_cap_usd=args.budget_cap_usd,
+        max_invocations=args.max_invocations,
+        max_billable_tokens=args.max_billable_tokens,
+        max_wall_seconds=args.max_wall_seconds,
+    )
+    model_selection = _model_selection_from_args(args)
+    if args.mode == "preflight":
+        return run_preflight(
+            pi_bin=args.pi_bin,
+            baseline_path=Path(args.baseline),
+            worktree=Path(args.worktree) if args.worktree else None,
+            budget_policy=budget_policy,
+            allow_live=args.allow_live,
+            pi_provider=args.pi_provider,
+            pi_model=args.pi_model,
+            pi_thinking=args.pi_thinking,
+            containment_receipt_path=Path(args.containment_receipt) if args.containment_receipt else None,
+            model_selection=model_selection,
+        )
+    if args.mode == "fixture-check":
+        return run_fixture_check(Path(args.baseline))
+    if args.mode == "live-host-receipt":
+        return run_live_host_receipt(
+            baseline_path=Path(args.baseline),
+            worktree=Path(args.worktree) if args.worktree else None,
+            allow_live=args.allow_live,
+            receipt_path=Path(args.receipt) if args.receipt else None,
+            diagnostic_dir=Path(args.diagnostic_dir),
+            budget_policy=budget_policy,
+            pi_bin=args.pi_bin,
+            pi_provider=args.pi_provider,
+            pi_model=args.pi_model,
+            pi_thinking=args.pi_thinking,
+            invocation_timeout_seconds=args.invocation_timeout_seconds,
+            model_selection=model_selection,
+            model_selection_receipt_path=Path(args.model_selection_receipt) if args.model_selection_receipt else None,
+        )
+    return run_live_calibration(
+        profile_path=Path(args.profile),
+        budget_targets_path=Path(args.budget_targets),
+        worktree=Path(args.worktree) if args.worktree else None,
+        runs_per_scenario_cohort=args.runs_per_scenario_cohort,
+        allow_live=args.allow_live,
+        receipt_path=Path(args.receipt) if args.receipt else None,
+        diagnostic_dir=Path(args.diagnostic_dir),
+        budget_policy=budget_policy,
+        pi_bin=args.pi_bin,
+        pi_provider=args.pi_provider,
+        pi_model=args.pi_model,
+        pi_thinking=args.pi_thinking,
+        invocation_timeout_seconds=args.invocation_timeout_seconds,
+        model_selection=model_selection,
+        model_selection_receipt_path=Path(args.model_selection_receipt) if args.model_selection_receipt else None,
+    )
+
+
+def run_preflight(
+    *,
+    pi_bin: str,
+    baseline_path: Path,
+    worktree: Path | None,
+    budget_policy: BudgetPolicy,
+    allow_live: bool,
+    pi_provider: str | None = None,
+    pi_model: str | None = None,
+    pi_thinking: str | None = None,
+    containment_receipt_path: Path | None = None,
+    model_selection: HostModelSelection | None = None,
+) -> dict[str, Any]:
+    blockers: list[dict[str, Any]] = []
+    checks: list[dict[str, Any]] = []
+    version = run_command([pi_bin, "--version"], checks, "pi-version")
+    help_result = run_command([pi_bin, "--help"], checks, "pi-help")
+    list_models = run_command(_list_models_command(pi_bin, model_selection=model_selection, pi_provider=pi_provider), checks, "pi-list-models")
+    baseline = load_json(baseline_path)
+    operations = _required_operations(baseline)
+    containment_policy = _containment_policy(pi_provider=pi_provider, pi_model=pi_model, pi_thinking=pi_thinking, model_selection=model_selection)
+    if not operations:
+        blockers.append({"code": "invalid-adapter-baseline", "message": "adapter baseline has no required operations"})
+    _validate_containment(containment_policy, blockers)
+    if allow_live:
+        try:
+            budget_policy.require_authorized(allow_live=allow_live, required_invocations=len(operations))
+        except HarnessError as error:
+            blockers.append({"code": error.code, "message": error.message})
+    if worktree is not None:
+        clean = _check_clean_worktree(worktree)
+        checks.append({"name": "clean-worktree", "status": "PASS" if clean.get("clean") else "FAIL", "details": clean})
+        if not clean.get("clean"):
+            blockers.append({"code": "BLOCKED_DIRTY_WORKTREE", "message": "live runs require a clean dedicated worktree"})
+    checks.append({"name": "budget-gate", "status": "PASS" if allow_live and not blockers else "BLOCKED", "details": {"budgetPolicy": budget_policy.to_json(), "allowLive": allow_live}})
+    commands_ok = all(result["returncode"] == 0 for result in (version, help_result, list_models))
+    status = "PASS" if not blockers and commands_ok else "FAIL"
+    if containment_receipt_path is not None:
+        write_json(
+            containment_receipt_path,
+            _containment_receipt(
+                status=status,
+                blockers=blockers,
+                policy=containment_policy,
+                pi_version=first_line(version["stdout"]),
+                model_catalog_available=list_models["returncode"] == 0,
+            ),
+        )
+    return {
+        **base_report(HARNESS_REPORT_SCHEMA, status, HOST, blockers),
+        "checks": checks,
+        "piVersion": first_line(version["stdout"]),
+        "modelCatalogAvailable": list_models["returncode"] == 0,
+        "baselineDigest": canonical_digest(baseline),
+        "requiredOperationCount": len(operations),
+        "containmentPolicy": containment_policy,
+        "containmentReceipt": file_identity(containment_receipt_path) if containment_receipt_path and containment_receipt_path.exists() else None,
+        "budgetPolicy": budget_policy.to_json(),
+        "modelSelection": model_selection.redacted_json() if model_selection else None,
+        "budgetMode": budget_policy.mode,
+        "budgetCapUsd": budget_policy.budget_cap_usd,
+        "liveCallsStarted": False,
+        "productionPromotionClaimed": False,
+    }
+
+
+def run_fixture_check(baseline_path: Path) -> dict[str, Any]:
+    return run_json_fixture_check(host=HOST, baseline_path=baseline_path, report_schema=HARNESS_REPORT_SCHEMA)
+
+
+def run_live_host_receipt(
+    *,
+    baseline_path: Path,
+    worktree: Path | None,
+    allow_live: bool,
+    receipt_path: Path | None,
+    diagnostic_dir: Path,
+    budget_policy: BudgetPolicy,
+    pi_bin: str = "pi",
+    pi_provider: str | None = None,
+    pi_model: str | None = None,
+    pi_thinking: str | None = None,
+    invocation_timeout_seconds: float = 600.0,
+    model_selection: HostModelSelection | None = None,
+    model_selection_receipt_path: Path | None = None,
+    runner: Callable[[list[str]], CommandResult] | None = None,
+    clean_worktree_checker: Callable[[Path], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return run_json_live_host_receipt(
+        host=HOST,
+        report_schema=HARNESS_REPORT_SCHEMA,
+        diagnostic_schema=DIAGNOSTIC_SCHEMA,
+        baseline_path=baseline_path,
+        worktree=worktree,
+        allow_live=allow_live,
+        receipt_path=receipt_path,
+        diagnostic_dir=diagnostic_dir,
+        budget_policy=budget_policy,
+        command_for_operation=lambda operation: _operation_command(
+            pi_bin,
+            operation,
+            pi_provider=pi_provider,
+            pi_model=pi_model,
+            pi_thinking=pi_thinking,
+            model_selection=model_selection,
+        ),
+        usage_parser=parse_pi_jsonl,
+        invocation_timeout_seconds=invocation_timeout_seconds,
+        model_selection=model_selection,
+        model_selection_receipt_path=model_selection_receipt_path,
+        extra_blockers=_containment_blockers(pi_provider=pi_provider, pi_model=pi_model, pi_thinking=pi_thinking, model_selection=model_selection),
+        runner=runner,
+        clean_worktree_checker=clean_worktree_checker,
+    )
+
+
+def run_live_calibration(
+    *,
+    profile_path: Path,
+    budget_targets_path: Path,
+    worktree: Path | None,
+    runs_per_scenario_cohort: int | None,
+    allow_live: bool,
+    receipt_path: Path | None,
+    diagnostic_dir: Path,
+    budget_policy: BudgetPolicy,
+    pi_bin: str = "pi",
+    pi_provider: str | None = None,
+    pi_model: str | None = None,
+    pi_thinking: str | None = None,
+    invocation_timeout_seconds: float = 600.0,
+    model_selection: HostModelSelection | None = None,
+    model_selection_receipt_path: Path | None = None,
+    runner: Callable[[list[str]], CommandResult] | None = None,
+    clean_worktree_checker: Callable[[Path], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return run_json_live_calibration(
+        host=HOST,
+        report_schema=HARNESS_REPORT_SCHEMA,
+        diagnostic_schema=DIAGNOSTIC_SCHEMA,
+        profile_path=profile_path,
+        budget_targets_path=budget_targets_path,
+        worktree=worktree,
+        runs_per_scenario_cohort=runs_per_scenario_cohort,
+        allow_live=allow_live,
+        receipt_path=receipt_path,
+        diagnostic_dir=diagnostic_dir,
+        budget_policy=budget_policy,
+        command_for_prompt=lambda prompt: _run_command(
+            pi_bin,
+            prompt,
+            pi_provider=pi_provider,
+            pi_model=pi_model,
+            pi_thinking=pi_thinking,
+            model_selection=model_selection,
+        ),
+        usage_parser=parse_pi_jsonl,
+        invocation_timeout_seconds=invocation_timeout_seconds,
+        model_selection=model_selection,
+        model_selection_receipt_path=model_selection_receipt_path,
+        extra_blockers=_containment_blockers(pi_provider=pi_provider, pi_model=pi_model, pi_thinking=pi_thinking, model_selection=model_selection),
+        runner=runner,
+        clean_worktree_checker=clean_worktree_checker,
+    )
+
+
+def parse_pi_jsonl(text: str, wall_seconds: float = 0.0) -> PiUsage:
+    events = parse_jsonl_objects(text)
+    session_id: str | None = None
+    selected_usage: dict[str, Any] = {}
+    cost_usd: float | None = None
+    for event in events:
+        session_id = session_id or _find_string(event, {"id", "session_id", "sessionId"})
+        for usage in _find_usage_dicts(event):
+            if _billable_tokens(usage) <= 0:
+                continue
+            selected_usage = usage
+            cost_usd = _host_reported_cost(usage)
+    input_tokens = _int_from_any(selected_usage.get("input"))
+    output_tokens = _int_from_any(selected_usage.get("output"))
+    billable_tokens = _billable_tokens(selected_usage)
+    return PiUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        billable_tokens=billable_tokens or input_tokens + output_tokens,
+        cumulative_context_bytes=None,
+        tool_calls=_count_tool_calls(events),
+        wall_seconds=round(wall_seconds, 3),
+        cost_usd=cost_usd,
+        session_id=session_id,
+        event_count=len(events),
+    )
+
+
+def _operation_command(pi_bin: str, operation_name: str, *, pi_provider: str | None, pi_model: str | None, pi_thinking: str | None, model_selection: HostModelSelection | None) -> list[str]:
+    return _run_command(
+        pi_bin,
+        (
+            f"ALK Pi live conformance probe. Operation: {operation_name}. "
+            "Do not use tools. Do not modify files. Reply only with compact JSON: {\"operation\":\"<operation>\",\"status\":\"PASS\"}."
+        ),
+        pi_provider=pi_provider,
+        pi_model=pi_model,
+        pi_thinking=pi_thinking,
+        model_selection=model_selection,
+    )
+
+
+def _run_command(pi_bin: str, prompt: str, *, pi_provider: str | None, pi_model: str | None, pi_thinking: str | None, model_selection: HostModelSelection | None) -> list[str]:
+    provider = pi_provider or (model_selection.provider if model_selection is not None else None)
+    model = pi_model or (model_selection.provider_model if model_selection is not None else None)
+    command = [
+        pi_bin,
+        "--mode",
+        "json",
+        "--no-session",
+        "--no-tools",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+        "--no-context-files",
+        "--no-approve",
+        "--offline",
+    ]
+    if provider:
+        command.extend(["--provider", provider])
+    if model:
+        command.extend(["--model", model])
+    if pi_thinking:
+        command.extend(["--thinking", pi_thinking])
+    command.extend(["--print", prompt])
+    return command
+
+
+def _list_models_command(pi_bin: str, *, model_selection: HostModelSelection | None, pi_provider: str | None) -> list[str]:
+    provider = pi_provider or (model_selection.provider if model_selection is not None else None)
+    command = [pi_bin, "--list-models"]
+    if provider:
+        command.append(provider)
+    command.append("--offline")
+    return command
+
+
+def _containment_blockers(*, pi_provider: str | None, pi_model: str | None, pi_thinking: str | None, model_selection: HostModelSelection | None) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    _validate_containment(_containment_policy(pi_provider=pi_provider, pi_model=pi_model, pi_thinking=pi_thinking, model_selection=model_selection), blockers)
+    return blockers
+
+
+def _containment_policy(*, pi_provider: str | None, pi_model: str | None, pi_thinking: str | None, model_selection: HostModelSelection | None) -> dict[str, Any]:
+    provider = pi_provider or (model_selection.provider if model_selection is not None else None)
+    model = pi_model or (model_selection.provider_model if model_selection is not None else None)
+    return {
+        "schemaVersion": "agent-pi-live-containment-policy.v1",
+        "host": HOST,
+        "jsonEvents": True,
+        "noSession": True,
+        "toolsDisabled": True,
+        "extensionsDisabled": True,
+        "skillsDisabled": True,
+        "promptTemplatesDisabled": True,
+        "themesDisabled": True,
+        "contextFilesDisabled": True,
+        "projectLocalFilesIgnored": True,
+        "startupNetworkDisabled": True,
+        "providerOverridePresent": provider is not None,
+        "modelOverridePresent": model is not None,
+        "thinkingOverridePresent": pi_thinking is not None,
+        "postInvocationCleanWorktreeRequired": True,
+        "promptPolicy": "no-tools-no-file-modifications-json-only",
+    }
+
+
+def _validate_containment(policy: dict[str, Any], blockers: list[dict[str, Any]]) -> None:
+    if policy.get("jsonEvents") is not True or policy.get("noSession") is not True:
+        blockers.append({"code": "BLOCKED_UNBOUNDED_HOST_INVOCATION", "message": "pi live promotion requires JSON event output and --no-session"})
+    if policy.get("toolsDisabled") is not True:
+        blockers.append({"code": "BLOCKED_UNBOUNDED_HOST_TOOLS", "message": "pi live promotion requires --no-tools"})
+    for key in ("extensionsDisabled", "skillsDisabled", "promptTemplatesDisabled", "themesDisabled", "contextFilesDisabled", "projectLocalFilesIgnored"):
+        if policy.get(key) is not True:
+            blockers.append({"code": "BLOCKED_UNBOUNDED_HOST_CONTEXT", "message": f"pi live promotion requires {key}"})
+    if policy.get("providerOverridePresent") is not True or policy.get("modelOverridePresent") is not True:
+        blockers.append({"code": "BLOCKED_MODEL_BINDING_UNDECLARED", "message": "pi live promotion requires explicit host-local provider and model"})
+
+
+def _containment_receipt(*, status: str, blockers: list[dict[str, Any]], policy: dict[str, Any], pi_version: str | None, model_catalog_available: bool) -> dict[str, Any]:
+    return {
+        "schemaVersion": "agent-pi-live-containment-receipt.v1",
+        "status": status,
+        "host": HOST,
+        "piVersion": pi_version,
+        "modelCatalogAvailable": model_catalog_available,
+        "policy": policy,
+        "blockers": blockers,
+        "productionPromotionClaimed": False,
+    }
+
+
+def _model_selection_from_args(args: argparse.Namespace) -> HostModelSelection | None:
+    if not args.host_model_profile:
+        return None
+    if not args.model_class:
+        raise HarnessError("missing-model-class", "--model-class is required with --host-model-profile")
+    return load_host_model_selection(Path(args.host_model_profile), model_class=args.model_class, binding_id=args.model_binding)
+
+
+def _check_clean_worktree(worktree: Path) -> dict[str, Any]:
+    from tools.live_hosts.json_cli_harness import check_clean_worktree
+
+    return check_clean_worktree(worktree)
+
+
+def _required_operations(baseline: dict[str, Any]) -> list[str]:
+    value = baseline.get("requiredOperations")
+    return [item for item in value if isinstance(item, str) and item] if isinstance(value, list) else []
+
+
+def _find_usage_dicts(value: Any) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == "usage" and isinstance(item, dict):
+                found.append(item)
+            found.extend(_find_usage_dicts(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.extend(_find_usage_dicts(item))
+    return found
+
+
+def _find_string(value: Any, keys: set[str]) -> str | None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in keys and isinstance(item, str) and item:
+                return item
+            found = _find_string(item, keys)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = _find_string(item, keys)
+            if found:
+                return found
+    return None
+
+
+def _count_tool_calls(value: Any) -> int:
+    if isinstance(value, dict):
+        total = 0
+        for key, item in value.items():
+            if key in {"toolResults", "tool_call", "toolCall", "tool_calls", "toolCalls"}:
+                if isinstance(item, list):
+                    total += len(item)
+                elif isinstance(item, dict):
+                    total += 1
+                elif isinstance(item, int) and not isinstance(item, bool):
+                    total += item
+            total += _count_tool_calls(item)
+        return total
+    if isinstance(value, list):
+        return sum(_count_tool_calls(item) for item in value)
+    return 0
+
+
+def _billable_tokens(usage: dict[str, Any]) -> int:
+    total = _int_from_any(usage.get("totalTokens"))
+    if total:
+        return total
+    return (
+        _int_from_any(usage.get("input"))
+        + _int_from_any(usage.get("output"))
+        + _int_from_any(usage.get("cacheRead"))
+        + _int_from_any(usage.get("cacheWrite"))
+    )
+
+
+def _host_reported_cost(usage: dict[str, Any]) -> float | None:
+    cost = usage.get("cost")
+    if not isinstance(cost, dict):
+        return None
+    total = cost.get("total")
+    if isinstance(total, (int, float)) and not isinstance(total, bool) and total > 0:
+        return float(total)
+    return None
+
+
+def _int_from_any(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/live_hosts/pi_install_probe.py
+++ b/tools/live_hosts/pi_install_probe.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agent_lifecycle.contracts import canonical_digest, sha256_hex  # noqa: E402
+from tools.live_hosts.json_cli_harness import first_line, write_json  # noqa: E402
+
+
+REPORT_SCHEMA = "agent-pi-install-probe-report.v1"
+DEFAULT_DESCRIPTOR = Path("adapters/pi/adapter.descriptor.json")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pi-bin", default="pi")
+    parser.add_argument("--descriptor", default=DEFAULT_DESCRIPTOR.as_posix())
+    parser.add_argument("--approved-source", required=True)
+    parser.add_argument("--expected-version")
+    parser.add_argument("--report", required=True)
+    args = parser.parse_args(argv)
+
+    report = run_probe(
+        pi_bin=args.pi_bin,
+        descriptor=Path(args.descriptor),
+        approved_source=args.approved_source,
+        expected_version=args.expected_version,
+    )
+    write_json(Path(args.report), report)
+    return 0 if report["status"] == "PASS" else 1
+
+
+def run_probe(*, pi_bin: str, descriptor: Path, approved_source: str, expected_version: str | None = None) -> dict[str, Any]:
+    blockers: list[dict[str, Any]] = []
+    checks: list[dict[str, Any]] = []
+    version = _run([pi_bin, "--version"], checks, "pi-version")
+    help_result = _run([pi_bin, "--help"], checks, "pi-help")
+    install_plan = _run(
+        [
+            sys.executable,
+            "-m",
+            "agent_lifecycle",
+            "adapter",
+            "install-plan",
+            "--descriptor",
+            descriptor.as_posix(),
+        ],
+        checks,
+        "pi-adapter-install-plan",
+        env_with_pythonpath=True,
+    )
+    version_line = first_line(version["stdout"])
+    if expected_version and version_line != expected_version:
+        blockers.append({"code": "pi-version-mismatch", "message": "installed Pi version does not match the expected version"})
+    if not approved_source.strip():
+        blockers.append({"code": "pi-install-source-missing", "message": "--approved-source must name the operator-approved source"})
+    install_plan_digest = sha256_hex(install_plan["stdout"].encode("utf-8")) if install_plan["returncode"] == 0 else None
+    commands_ok = all(item["returncode"] == 0 for item in (version, help_result, install_plan))
+    return {
+        "schemaVersion": REPORT_SCHEMA,
+        "status": "PASS" if commands_ok and not blockers else "FAIL",
+        "host": "pi",
+        "approvedSourceDigest": canonical_digest({"approvedSource": approved_source}),
+        "piVersion": version_line,
+        "expectedVersion": expected_version,
+        "installPlanStdoutSha256": install_plan_digest,
+        "checks": checks,
+        "blockers": blockers,
+        "writesStarted": False,
+        "liveCallsStarted": False,
+        "productionPromotionClaimed": False,
+    }
+
+
+def _run(command: list[str], checks: list[dict[str, Any]], name: str, *, env_with_pythonpath: bool = False) -> dict[str, Any]:
+    started = time.monotonic()
+    env = None
+    if env_with_pythonpath:
+        import os
+
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(SRC)
+    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, check=False)
+    elapsed = round(time.monotonic() - started, 3)
+    checks.append(
+        {
+            "name": name,
+            "status": "PASS" if result.returncode == 0 else "FAIL",
+            "returncode": result.returncode,
+            "stdoutSha256": sha256_hex(result.stdout.encode("utf-8")),
+            "stderrSha256": sha256_hex(result.stderr.encode("utf-8")),
+            "wallSeconds": elapsed,
+        }
+    )
+    return {"returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release/validate_docs_compat.py
+++ b/tools/release/validate_docs_compat.py
@@ -361,6 +361,8 @@ def _check_adapter_doc(root: Path, relative: str, blockers: list[dict[str, Any]]
         required = ("`VERIFIED`", "Qwen Code `0.21.0`", "live conformance", "does not claim public")
     elif relative == "docs/adapters/openinterpreter.md" and "OpenInterpreter" in verified_doc_hosts:
         required = ("`VERIFIED`", "`interpreter` 0.0.34", "live conformance", "does not claim public")
+    elif relative == "docs/adapters/pi.md" and "Pi" in verified_doc_hosts:
+        required = ("`VERIFIED`", "Pi `0.83.0`", "live conformance", "does not claim public")
     else:
         required = ("`EXPERIMENTAL`", "live", "conformance")
     check = _check_doc(root, relative, required, blockers, verified_doc_hosts)
@@ -378,6 +380,7 @@ def _check_adapter_doc(root: Path, relative: str, blockers: list[dict[str, Any]]
                 "docs/adapters/hermes.md",
                 "docs/adapters/qwen-code.md",
                 "docs/adapters/openinterpreter.md",
+                "docs/adapters/pi.md",
             }
             and "until live" not in text
             and "not `VERIFIED`" not in text

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11,<3.14"
 
 [[package]]
 name = "agent-lifecycle-kit"
-version = "1.18.0"
+version = "1.19.0"
 source = { editable = "." }
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- Promote the Pi adapter to VERIFIED for Pi 0.83.0 with tracked redacted live evidence summary.
- Add Pi live harness/probe coverage and include Pi in live calibration/conformance profiles.
- Update adapter docs, install docs, Russian docs, support matrix, descriptors, receipts, manifests, and release inventory.

## Validation
- python3 -m unittest discover -s tests -p 'test*.py' -q
- tools/release/verify_release_candidate.py
- tools/release/validate_adapter_conformance.py
- tools/release/validate_support_matrix.py
- tools/release/validate_docs_compat.py
- tools/release/validate_live_host_conformance.py --promoted-hosts pi
- tools/release/validate_live_calibration.py --promoted-hosts pi
- tests/package/run_packaging_smoke.py

## Evidence
- Local live evidence is under work/release-1-19/evidence and summarized in docs/adapters/evidence/pi-live-verified.md.
- Secrets remain host-local via --host-env-file/--host-env-allow and are not persisted in receipts.