### PR TITLE
Docs: polish README layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use it when you want Codex, Claude Code, Qwen Code, Goose, OpenInterpreter, Pi,
 Grok Build, or another CLI to follow the same quality loop without putting
 provider, model, or secret policy into the core.
 
-## Quick Start
+## Quick start
 
 From a source checkout:
 
@@ -31,7 +31,7 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
 For a short walkthrough, use [Quickstart](docs/guides/quickstart.md). The
 Russian documentation starts at [Документация на русском](docs/ru/README.md).
 
-## Why Try It
+## Why try it
 
 - Finish-oriented lifecycle: plan, execute, review, and prove the result.
 - Provider-neutral adapters: host-specific commands stay outside the core.
@@ -42,9 +42,9 @@ Russian documentation starts at [Документация на русском](d
 - Usage visibility: token/resource accounting is native; USD cost is optional
   and only used when a metered host reports it.
 
-## Feature Areas
+## Feature areas
 
-### Plan And Execute
+### Plan and execute
 
 - Reviewed specification and plan flow before implementation starts.
 - Deterministic task packets for splitting work across agents.
@@ -53,7 +53,7 @@ Russian documentation starts at [Документация на русском](d
 - Draft-only task templates for bugfix, idea-to-PR, PR review, merge-conflict
   repair, and release-readiness work.
 
-### Quality And Proof
+### Quality and proof
 
 - Implementation audits compare results with the frozen plan and acceptance
   evidence.
@@ -65,7 +65,7 @@ Russian documentation starts at [Документация на русском](d
 - Optional cross-check, runtime policy, and write-back receipts stay off by
   default and become blocking only when the plan says so.
 
-### Routing And Cost Control
+### Routing and cost control
 
 - Compact context profiles, small-model packets, objective snapshots, and
   local quality-cost learning help choose the lightest safe mode.
@@ -74,7 +74,7 @@ Russian documentation starts at [Документация на русском](d
 - Usage/session exports include tokens, resources, receipt digests, and optional
   host-reported `cost_usd`.
 
-### Adapters And Interop
+### Adapters and interop
 
 - Adapter contracts keep host-specific projections separate from lifecycle
   schemas.
@@ -94,14 +94,14 @@ Russian documentation starts at [Документация на русском](d
 - Read-only diagnostics, event feeds, and progress views inspect checkout and
   workflow state without model calls.
 
-## Daily Flow
+## Daily flow
 
 Spec -> frozen plan -> bounded work -> implementation audit -> final proof.
 Core commands cover specification, plan, workflow, audit, adapters, imports,
 metrics, policy, diagnostics, and runner state. See [CLI reference](docs/reference/cli.md)
 and [Source of truth](docs/reference/source-of-truth.md).
 
-## Adapter Maturity
+## Adapter maturity
 
 `EXPERIMENTAL` means the adapter has source projection metadata and deterministic
 offline checks, but it is not promoted. `VERIFIED` is host-specific and requires
@@ -128,13 +128,13 @@ Adapter installation and maturity details live in
 [Adapter install](docs/adapters/install.md) and
 [Adapter support matrix](docs/adapters/support-matrix.md).
 
-## Contract Map
+## Contract map
 
 The public lifecycle surface is schema-backed. Full stable schema ids,
 compatibility rules, runner recovery, cross-check, Bug Forensics, and usage
 export details are listed in [Public contracts](docs/reference/public-contracts.md).
 
-## Design Boundaries
+## Design boundaries
 
 - The core stays provider-neutral. Concrete host commands and model bindings
   belong to adapters or host-local profiles.

--- a/docs/assets/agent-lifecycle-kit-banner.svg
+++ b/docs/assets/agent-lifecycle-kit-banner.svg
@@ -2,38 +2,38 @@
   <title id="title">Agent Lifecycle Kit banner</title>
   <desc id="desc">Agent Lifecycle Kit: plan, execute, prove, and finish agent work.</desc>
   <rect width="1200" height="360" rx="28" fill="#101418"/>
-  <g fill="none" stroke="#93a4b8" stroke-width="4" stroke-linecap="round">
-    <path d="M248 182h112"/>
-    <path d="M480 182h112"/>
-    <path d="M712 182h112"/>
-    <path d="M936 182c38 0 58 24 58 52s-20 52-58 52H310c-38 0-58-24-58-52"/>
-  </g>
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
-    <g>
-      <circle cx="188" cy="182" r="60" fill="#f4f7fb"/>
-      <path d="M165 185l16 16 34-42" fill="none" stroke="#0e6f64" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
-      <text x="188" y="270" text-anchor="middle" font-size="24" font-weight="700" fill="#dbe5ee">SPEC</text>
+    <text x="600" y="72" text-anchor="middle" font-size="54" font-weight="800" fill="#ffffff">Agent Lifecycle Kit</text>
+    <text x="600" y="114" text-anchor="middle" font-size="24" fill="#b9c7d6">Plan. Execute. Prove. Finish agent work.</text>
+    <g fill="#f4f7fb">
+      <circle cx="250" cy="200" r="42"/>
+      <circle cx="483" cy="200" r="42"/>
+      <circle cx="716" cy="200" r="42"/>
+      <circle cx="949" cy="200" r="42"/>
+    </g>
+    <g fill="none" stroke="#93a4b8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M250 200c0-66 699-66 699 0s-699 66-699 0z"/>
+      <path d="M250 200h699" opacity=".72"/>
     </g>
     <g>
-      <circle cx="420" cy="182" r="60" fill="#f4f7fb"/>
-      <path d="M392 157h56v50h-56z" fill="none" stroke="#315f9f" stroke-width="10" stroke-linejoin="round"/>
-      <path d="M405 175h30M405 191h22" stroke="#315f9f" stroke-width="8" stroke-linecap="round"/>
-      <text x="420" y="270" text-anchor="middle" font-size="24" font-weight="700" fill="#dbe5ee">PLAN</text>
+      <path d="M234 202l11 11 25-31" fill="none" stroke="#0e6f64" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="250" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">SPEC</text>
     </g>
     <g>
-      <circle cx="652" cy="182" r="60" fill="#f4f7fb"/>
-      <path d="M628 152h44l22 30-42 48-42-48z" fill="none" stroke="#7a4b15" stroke-width="9" stroke-linejoin="round"/>
-      <path d="M628 152l24 78 20-78" stroke="#7a4b15" stroke-width="7" stroke-linejoin="round"/>
-      <text x="652" y="270" text-anchor="middle" font-size="24" font-weight="700" fill="#dbe5ee">WORK</text>
+      <path d="M464 177h38v34h-38z" fill="none" stroke="#315f9f" stroke-width="7" stroke-linejoin="round"/>
+      <path d="M473 190h20M473 201h15" stroke="#315f9f" stroke-width="6" stroke-linecap="round"/>
+      <text x="483" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">PLAN</text>
     </g>
     <g>
-      <circle cx="884" cy="182" r="60" fill="#f4f7fb"/>
-      <path d="M855 187l18 18 39-48" fill="none" stroke="#6f3f91" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M850 220h68" stroke="#6f3f91" stroke-width="8" stroke-linecap="round"/>
-      <text x="884" y="270" text-anchor="middle" font-size="24" font-weight="700" fill="#dbe5ee">PROOF</text>
+      <path d="M699 179h34l17 23-34 38-34-38z" fill="none" stroke="#7a4b15" stroke-width="7" stroke-linejoin="round"/>
+      <path d="M699 179l17 61 17-61" stroke="#7a4b15" stroke-width="5" stroke-linejoin="round"/>
+      <text x="716" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">WORK</text>
     </g>
-    <text x="96" y="86" font-size="54" font-weight="800" fill="#ffffff">Agent Lifecycle Kit</text>
-    <text x="96" y="128" font-size="24" fill="#b9c7d6">Plan. Execute. Prove. Finish agent work.</text>
-    <text x="1090" y="316" text-anchor="end" font-size="22" font-weight="700" fill="#9cc9bd">ALK</text>
+    <g>
+      <path d="M930 203l13 13 29-36" fill="none" stroke="#6f3f91" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M925 227h49" stroke="#6f3f91" stroke-width="6" stroke-linecap="round"/>
+      <text x="949" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">PROOF</text>
+    </g>
+    <text x="600" y="326" text-anchor="middle" font-size="22" font-weight="700" fill="#9cc9bd">ALK</text>
   </g>
 </svg>

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -9,61 +9,66 @@ Agent Lifecycle Kit (ALK) - provider-neutral контрольный слой д�
 
 **Лицензия:** Apache-2.0 · **Версия:** 1.29.0 · **Python:** 3.11-3.13
 
-```mermaid
-flowchart LR
-  request[Задача] --> spec[Проверенная спецификация]
-  spec --> plan[Зафиксированный план]
-  plan --> work[Ограниченные пакеты работ]
-  work --> review[Проверка реализации]
-  review --> proof[Финальное подтверждение]
-  proof --> done[Завершено или оформлено как продолжение]
-  review -->|блокер| plan
-```
+## Почему стоит попробовать
 
-## Что входит
+- Жизненный цикл ориентирован на завершение: план, выполнение, проверка и proof.
+- Ядро нейтрально к провайдерам; команды конкретных CLI остаются в адаптерах.
+- Маленькие и локальные модели получают компактный контекст, явный следующий шаг
+  и детерминированные проверки.
+- Дополнительные профили включаются только по типу задачи или уровню риска.
+- Учёт расхода показывает токены и ресурсы; USD-cost необязателен и используется
+  только когда metered-хост сам его сообщает.
+
+## Области возможностей
+
+### Планирование и выполнение
 
 - Спецификация и план проверяются до начала реализации.
 - Работа разбивается на пакеты с владельцем, границами записи и критериями
   приёмки.
 - Выполнение, completion gate, блокировки, повторные попытки и финальное
   подтверждение фиксируются в структурированных артефактах.
-- Контракты адаптеров не смешивают детали конкретного хоста с ядром.
-- Маленькие локальные модели получают small-model packets, компактный контекст
-  и явный следующий шаг вместо длинной истории.
-- Отчёты о расходе разделяют практическую работу, проверку продукта, контроль
-  жизненного цикла и координацию.
-- Экспорт использования показывает сессии, токены, ресурсы, digest
-  подтверждений и необязательный `cost_usd`, если его сообщает metered-хост.
-- Дополнительный proof-integrity слой для багфиксов и рискованных финальных
-  подтверждений: стабильные findings, digest root cause, fix-impact receipts и
-  hash chain.
-- Дополнительные sandbox receipts для рискованных задач: filesystem, network,
-  process, environment и enforcement source фиксируются отдельно от git
-  write-scope, включая partial containment и redacted credential proxy
-  boundaries.
-- Release-time capability bench строит bounded probe plans из capability
-  manifests и проверяет live receipts на drift без изменения maturity.
-- Import mapper profiles для generic workflow/agent dialects, Constitution/ADR
-  и AGENTS/agentskills; результат остаётся untrusted draft с digest dialect
-  profile.
-- Issue-to-spec intake держит внешние тикеты как draft-only вход до review/freeze.
-- Draft-only task templates для bugfix, idea-to-PR, PR review,
-  merge-conflict repair и release-readiness задач.
-- Лёгкий episode retrieval по receipt/session summaries с digest provenance и
-  явным состоянием `chainVerified` или `chainUnchecked`.
-- Runner recovery receipts для snapshot, restore, abandon, selected attempt,
-  worker lease и heartbeat state.
-- Optional cross-check profile для рискованных задач: выключен по умолчанию,
-  capped в tokens/resources и advisory, пока план явно не делает его blocking.
-- Optional Bug Forensics profile для явных bug/regression repair задач:
+- Draft-only task templates покрывают bugfix, idea-to-PR, PR review,
+  merge-conflict repair и release-readiness задачи.
+
+### Качество и подтверждение
+
+- Проверка реализации сравнивает результат с frozen plan и acceptance evidence.
+- Optional Bug Forensics profile для bug/regression repair задач фиксирует
   reproduction-before-fix, stable fingerprint, hypothesis ledger, minimal patch
   gate, same-fingerprint regression proof и reusable recipes.
+- Proof-integrity слой для рискованных финальных подтверждений хранит stable
+  findings, digest root cause, fix-impact receipts и hash chain.
+- Optional cross-check, runtime policy и write-back receipts выключены по
+  умолчанию и становятся blocking только если это явно задано в плане.
+
+### Маршрутизация и расход
+
+- Small-model packets, compact context profiles, objective snapshots и
+  quality-cost learning помогают выбрать самый лёгкий безопасный режим.
 - Phase resource measurements используют usage export envelope для токенов,
   длительности и resource counters без обязательного USD-cost.
-- Adaptive lifecycle policy, failure-aware routing и предложения по настройке
-  правил выбирают самый лёгкий безопасный режим по нейтральным evidence.
-- Диагностика готовности, event feeds и lifecycle progress views по умолчанию
-  не пишут state и не запускают реальные модельные вызовы.
+- Экспорт использования показывает сессии, токены, ресурсы, digest
+  подтверждений и необязательный host-reported `cost_usd`.
+
+### Адаптеры и импорт
+
+- Контракты адаптеров не смешивают детали конкретного хоста с lifecycle schemas.
+- Release-time capability bench строит bounded probe plans и проверяет live
+  receipts на drift без автоматического изменения maturity.
+- Import mappers и issue-to-spec intake держат внешние workflow, agent dialects и
+  тикеты как untrusted draft inputs.
+- Episode retrieval ищет по receipt/session summaries с digest provenance и
+  состоянием `chainVerified` или `chainUnchecked`.
+
+### Операции
+
+- Runner recovery receipts покрывают snapshot, restore, abandon, selected
+  attempt, worker lease и heartbeat state.
+- Sandbox receipts для рискованных задач описывают runtime containment отдельно
+  от git write-scope.
+- Диагностика готовности, event feeds и lifecycle progress views по умолчанию не
+  пишут state и не запускают реальные модельные вызовы.
 
 ## Быстрый старт
 
@@ -80,34 +85,10 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
 
 ## Обычный цикл
 
-1. Уточнить задачу и ограничения.
-2. Подготовить спецификацию и план.
-3. Проверить план и зафиксировать его.
-4. Выполнить ограниченные пакеты работ.
-5. Проверить реализацию по плану.
-6. Завершить задачу только после приёмки, подтверждающих артефактов и оценки
-   остаточных рисков.
-
-Основные группы команд:
-
-- `agent-lifecycle specification`: проверка спецификации и completion gate.
-- `agent-lifecycle plan`: проверка плана, файл блокировки, снимки и передача
-  контекста.
-- `agent-lifecycle workflow`: отчёты о выполнении задач и финальное
-  подтверждение.
-- `agent-lifecycle audit`: проверка плана и реализации.
-- `agent-lifecycle metrics`: отчёты о расходе, экспорт использования и
-  проверка этих отчётов.
-- `agent-lifecycle policy`: adaptive decisions, runtime receipts и предложения
-  по настройке правил.
-- `agent-lifecycle diagnostics`: обезличенные диагностические пакеты.
-- `agent-lifecycle diagnose`: проверка готовности исходного дерева без записи и
-  без реальных вызовов моделей.
-- `agent-lifecycle adapter`: проверка, осмотр, заготовка адаптера, события и
-  пробный план установки.
-
-Подробности: [Справочник команд](reference/cli.md) и
-[источник правды](reference/source-of-truth.md).
+Обычный путь: спецификация -> frozen plan -> bounded work -> проверка реализации
+-> final proof. Основные команды покрывают specification, plan, workflow, audit,
+adapter, import, metrics, policy, diagnostics и runner state. Подробности:
+[Справочник команд](reference/cli.md) и [источник правды](reference/source-of-truth.md).
 
 ## Зрелость адаптеров
 


### PR DESCRIPTION
## Summary
- center the README banner title and subtitle
- reduce banner lifecycle icons by roughly 30% and make the connector continuous through them
- convert English README headings to sentence case
- restructure the Russian README feature list into the same grouped sections as the English README

## Validation
- xmllint --noout docs/assets/agent-lifecycle-kit-banner.svg
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest tests.release.test_docs_gates -q
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 tools/release/validate_docs_compat.py --evidence work/docs-readme-polish/evidence/docs-compat.json
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest discover -s tests -q
- git diff --check