### PR TITLE
Docs: update repository banner

### DIFF
--- a/docs/assets/agent-lifecycle-kit-banner.svg
+++ b/docs/assets/agent-lifecycle-kit-banner.svg
@@ -1,39 +1,111 @@
-<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1200 360">
-  <title id="title">Agent Lifecycle Kit banner</title>
-  <desc id="desc">Agent Lifecycle Kit: plan, execute, prove, and finish agent work.</desc>
-  <rect width="1200" height="360" rx="28" fill="#101418"/>
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1200 630">
+  <title id="title">Agent Lifecycle Kit social card</title>
+  <desc id="desc">Agent Lifecycle Kit turns coding-agent work into a reviewed, bounded, and proven lifecycle.</desc>
+  <defs>
+    <pattern id="grid" width="80" height="80" patternUnits="userSpaceOnUse">
+      <path d="M80 0H0V80" fill="none" stroke="#263141" stroke-width="1"/>
+    </pattern>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="9" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2 2l8 4-8 4z" fill="#5eb4ff"/>
+    </marker>
+  </defs>
+  <rect width="1200" height="630" rx="34" fill="#101418"/>
+  <rect width="1200" height="630" rx="34" fill="url(#grid)" opacity=".45"/>
+  <path d="M120 490c220 86 728 86 960-28" fill="none" stroke="#1b6f6c" stroke-width="2" opacity=".45"/>
+  <path d="M98 142h1004" stroke="#202a37" stroke-width="2"/>
+
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
-    <text x="600" y="72" text-anchor="middle" font-size="54" font-weight="800" fill="#ffffff">Agent Lifecycle Kit</text>
-    <text x="600" y="114" text-anchor="middle" font-size="24" fill="#b9c7d6">Plan. Execute. Prove. Finish agent work.</text>
-    <g fill="#f4f7fb">
-      <circle cx="250" cy="200" r="42"/>
-      <circle cx="483" cy="200" r="42"/>
-      <circle cx="716" cy="200" r="42"/>
-      <circle cx="949" cy="200" r="42"/>
+    <g transform="translate(389 34)">
+      <rect width="422" height="34" rx="17" fill="#121b26" stroke="#2c3c50"/>
+      <circle cx="22" cy="17" r="5" fill="#35d4c9"/>
+      <text x="40" y="22" font-size="15" font-weight="700" fill="#c5d2e2">OPEN SOURCE · Apache-2.0 · v1.29.0 · Python 3.11-3.13</text>
     </g>
-    <g fill="none" stroke="#93a4b8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M250 200c0-66 699-66 699 0s-699 66-699 0z"/>
-      <path d="M250 200h699" opacity=".72"/>
+
+    <text x="600" y="118" text-anchor="middle" font-size="58" font-weight="800" fill="#ffffff">Agent Lifecycle Kit</text>
+    <path d="M432 138h336" stroke="#5eb4ff" stroke-width="6" stroke-linecap="round"/>
+    <path d="M432 148h186" stroke="#a468ff" stroke-width="5" stroke-linecap="round"/>
+    <text x="600" y="184" text-anchor="middle" font-size="25" font-weight="600" fill="#d7e2ee">Provider-neutral control layer for coding agents</text>
+    <text x="600" y="218" text-anchor="middle" font-size="19" fill="#95a8bb">From a task request to a reviewed spec, frozen plan, bounded work, audit, and final proof.</text>
+
+    <g fill="none" stroke="#5eb4ff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)">
+      <path d="M172 294h116"/>
+      <path d="M342 294h116"/>
+      <path d="M512 294h116"/>
+      <path d="M682 294h116"/>
+      <path d="M852 294h116"/>
     </g>
-    <g>
-      <path d="M234 202l11 11 25-31" fill="none" stroke="#0e6f64" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
-      <text x="250" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">SPEC</text>
+
+    <g font-weight="800" text-anchor="middle">
+      <g>
+        <circle cx="134" cy="294" r="42" fill="#141c27" stroke="#5d78ff" stroke-width="2"/>
+        <text x="134" y="300" font-size="18" fill="#ffffff">01</text>
+        <text x="134" y="360" font-size="18" fill="#dbe6f2">Request</text>
+      </g>
+      <g>
+        <circle cx="304" cy="294" r="42" fill="#141c27" stroke="#35d4c9" stroke-width="2"/>
+        <path d="M286 286h36M286 298h24" stroke="#35d4c9" stroke-width="5" stroke-linecap="round"/>
+        <text x="304" y="360" font-size="18" fill="#dbe6f2">Spec</text>
+      </g>
+      <g>
+        <circle cx="474" cy="294" r="42" fill="#141c27" stroke="#a468ff" stroke-width="2"/>
+        <path d="M454 272h40v44h-40zM463 284h22M463 296h26M463 308h16" fill="none" stroke="#a468ff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+        <text x="474" y="360" font-size="18" fill="#dbe6f2">Plan</text>
+      </g>
+      <g>
+        <circle cx="644" cy="294" r="42" fill="#141c27" stroke="#f0a243" stroke-width="2"/>
+        <path d="M622 292l22-24 22 24-22 28zM622 292h44" fill="none" stroke="#f0a243" stroke-width="5" stroke-linejoin="round"/>
+        <text x="644" y="360" font-size="18" fill="#dbe6f2">Work</text>
+      </g>
+      <g>
+        <circle cx="814" cy="294" r="42" fill="#141c27" stroke="#ff6f91" stroke-width="2"/>
+        <path d="M794 297l13 13 29-38" fill="none" stroke="#ff6f91" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+        <text x="814" y="360" font-size="18" fill="#dbe6f2">Audit</text>
+      </g>
+      <g>
+        <circle cx="984" cy="294" r="42" fill="#141c27" stroke="#35d4c9" stroke-width="2"/>
+        <path d="M964 295l14 14 31-40" fill="none" stroke="#35d4c9" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M958 321h52" stroke="#35d4c9" stroke-width="5" stroke-linecap="round"/>
+        <text x="984" y="360" font-size="18" fill="#dbe6f2">Proof</text>
+      </g>
     </g>
-    <g>
-      <path d="M464 177h38v34h-38z" fill="none" stroke="#315f9f" stroke-width="7" stroke-linejoin="round"/>
-      <path d="M473 190h20M473 201h15" stroke="#315f9f" stroke-width="6" stroke-linecap="round"/>
-      <text x="483" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">PLAN</text>
+
+    <g transform="translate(78 408)">
+      <text x="0" y="0" font-size="15" font-weight="800" fill="#8fa5bb">HOST-NEUTRAL ADAPTERS</text>
+      <g font-size="16" font-weight="700" fill="#eaf2fb">
+        <rect x="0" y="24" width="128" height="38" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="64" y="49" text-anchor="middle">Codex</text>
+        <rect x="140" y="24" width="142" height="38" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="211" y="49" text-anchor="middle">Claude Code</text>
+        <rect x="294" y="24" width="126" height="38" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="357" y="49" text-anchor="middle">Qwen Code</text>
+        <rect x="432" y="24" width="104" height="38" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="484" y="49" text-anchor="middle">Goose</text>
+        <rect x="0" y="74" width="162" height="38" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="81" y="99" text-anchor="middle">OpenInterpreter</text>
+        <rect x="174" y="74" width="70" height="38" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="209" y="99" text-anchor="middle">Pi</text>
+        <rect x="256" y="74" width="124" height="38" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="318" y="99" text-anchor="middle">Grok Build</text>
+      </g>
     </g>
-    <g>
-      <path d="M699 179h34l17 23-34 38-34-38z" fill="none" stroke="#7a4b15" stroke-width="7" stroke-linejoin="round"/>
-      <path d="M699 179l17 61 17-61" stroke="#7a4b15" stroke-width="5" stroke-linejoin="round"/>
-      <text x="716" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">WORK</text>
+
+    <g transform="translate(724 398)">
+      <rect width="398" height="146" rx="16" fill="#111923" stroke="#2d3d52"/>
+      <text x="28" y="36" font-size="18" font-weight="800" fill="#ffffff">What is different</text>
+      <g font-size="16" fill="#d7e2ee">
+        <circle cx="34" cy="66" r="4" fill="#35d4c9"/>
+        <text x="50" y="72">State lives in receipts, not chat memory</text>
+        <circle cx="34" cy="96" r="4" fill="#5eb4ff"/>
+        <text x="50" y="102">Freeze-gate before implementation</text>
+        <circle cx="34" cy="126" r="4" fill="#f0a243"/>
+        <text x="50" y="132">Token/resource routing, USD optional</text>
+      </g>
     </g>
-    <g>
-      <path d="M930 203l13 13 29-36" fill="none" stroke="#6f3f91" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M925 227h49" stroke="#6f3f91" stroke-width="6" stroke-linecap="round"/>
-      <text x="949" y="284" text-anchor="middle" font-size="21" font-weight="700" fill="#dbe5ee">PROOF</text>
+
+    <g transform="translate(78 568)">
+      <rect width="476" height="38" rx="10" fill="#111923" stroke="#2d3d52"/>
+      <text x="20" y="25" font-size="17" fill="#d7e2ee">github.com/avksp/agent-lifecycle-kit</text>
     </g>
-    <text x="600" y="326" text-anchor="middle" font-size="22" font-weight="700" fill="#9cc9bd">ALK</text>
+    <text x="1120" y="594" text-anchor="end" font-size="20" font-weight="800" fill="#9cc9bd">Plan · Execute · Prove · Finish</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the README banner with a current ALK v1.29.0 social-card style image
- keep the visual focused on the current lifecycle: request, spec, plan, work, audit, and proof
- show current positioning: provider-neutral adapters, receipts/state outside chat, freeze gates, and token/resource routing

## Validation
- xmllint --noout docs/assets/agent-lifecycle-kit-banner.svg
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest tests.release.test_docs_gates -q

Reference: https://t.me/deksden_notes/1024