### PR TITLE
Docs: tune repository banner layout

### DIFF
--- a/docs/assets/agent-lifecycle-kit-banner.svg
+++ b/docs/assets/agent-lifecycle-kit-banner.svg
@@ -12,104 +12,106 @@
   <rect width="1200" height="630" rx="34" fill="#101418"/>
   <rect width="1200" height="630" rx="34" fill="url(#grid)" opacity=".45"/>
   <path d="M120 490c220 86 728 86 960-28" fill="none" stroke="#1b6f6c" stroke-width="2" opacity=".45"/>
-  <path d="M98 142h1004" stroke="#202a37" stroke-width="2"/>
 
   <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
-    <g transform="translate(464 34)">
-      <rect width="272" height="34" rx="17" fill="#121b26" stroke="#2c3c50"/>
+    <g transform="translate(460 26)">
+      <rect width="280" height="34" rx="17" fill="#121b26" stroke="#2c3c50"/>
       <circle cx="22" cy="17" r="5" fill="#35d4c9"/>
-      <text x="146" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#c5d2e2">OPEN SOURCE · Apache-2.0</text>
+      <text x="150" y="22" text-anchor="middle" font-size="15" font-weight="700" fill="#c5d2e2">OPEN SOURCE · Apache-2.0</text>
     </g>
 
-    <text x="600" y="118" text-anchor="middle" font-size="58" font-weight="800" fill="#ffffff">Agent Lifecycle Kit</text>
-    <path d="M432 138h336" stroke="#5eb4ff" stroke-width="6" stroke-linecap="round"/>
-    <path d="M432 148h186" stroke="#a468ff" stroke-width="5" stroke-linecap="round"/>
-    <text x="600" y="184" text-anchor="middle" font-size="25" font-weight="600" fill="#d7e2ee">Provider-neutral control layer for coding agents</text>
-    <text x="600" y="218" text-anchor="middle" font-size="19" fill="#95a8bb">From a task request to a reviewed spec, frozen plan, bounded work, audit, and final proof.</text>
+    <text x="600" y="130" text-anchor="middle" font-size="58" font-weight="800" fill="#ffffff">Agent Lifecycle Kit</text>
+    <path d="M432 156h336" stroke="#5eb4ff" stroke-width="6" stroke-linecap="round"/>
+    <path d="M432 168h186" stroke="#a468ff" stroke-width="5" stroke-linecap="round"/>
+    <path d="M98 182h1004" stroke="#202a37" stroke-width="2"/>
+    <text x="600" y="214" text-anchor="middle" font-size="25" font-weight="600" fill="#d7e2ee">Provider-neutral control layer for coding agents</text>
+    <text x="600" y="248" text-anchor="middle" font-size="19" fill="#95a8bb">From a task request to a reviewed spec, frozen plan, bounded work, audit, and final proof.</text>
 
     <g fill="none" stroke="#5eb4ff" stroke-width="4" stroke-linecap="round" marker-end="url(#arrow)">
-      <path d="M172 294h116"/>
-      <path d="M342 294h116"/>
-      <path d="M512 294h116"/>
-      <path d="M682 294h116"/>
-      <path d="M852 294h116"/>
+      <path d="M172 330h116"/>
+      <path d="M342 330h116"/>
+      <path d="M512 330h116"/>
+      <path d="M682 330h116"/>
+      <path d="M852 330h116"/>
     </g>
 
     <g font-weight="800" text-anchor="middle">
       <g>
-        <circle cx="134" cy="294" r="42" fill="#141c27" stroke="#5d78ff" stroke-width="2"/>
-        <text x="134" y="300" font-size="18" fill="#ffffff">01</text>
-        <text x="134" y="360" font-size="18" fill="#dbe6f2">Request</text>
+        <circle cx="134" cy="330" r="42" fill="#141c27" stroke="#5d78ff" stroke-width="2"/>
+        <text x="134" y="336" font-size="18" fill="#ffffff">01</text>
+        <text x="134" y="396" font-size="18" fill="#dbe6f2">Request</text>
       </g>
       <g>
-        <circle cx="304" cy="294" r="42" fill="#141c27" stroke="#35d4c9" stroke-width="2"/>
-        <path d="M286 286h36M286 298h24" stroke="#35d4c9" stroke-width="5" stroke-linecap="round"/>
-        <text x="304" y="360" font-size="18" fill="#dbe6f2">Spec</text>
+        <circle cx="304" cy="330" r="42" fill="#141c27" stroke="#35d4c9" stroke-width="2"/>
+        <path d="M286 322h36M286 334h24" stroke="#35d4c9" stroke-width="5" stroke-linecap="round"/>
+        <text x="304" y="396" font-size="18" fill="#dbe6f2">Spec</text>
       </g>
       <g>
-        <circle cx="474" cy="294" r="42" fill="#141c27" stroke="#a468ff" stroke-width="2"/>
-        <path d="M454 272h40v44h-40zM463 284h22M463 296h26M463 308h16" fill="none" stroke="#a468ff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
-        <text x="474" y="360" font-size="18" fill="#dbe6f2">Plan</text>
+        <circle cx="474" cy="330" r="42" fill="#141c27" stroke="#a468ff" stroke-width="2"/>
+        <path d="M454 308h40v44h-40zM463 320h22M463 332h26M463 344h16" fill="none" stroke="#a468ff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+        <text x="474" y="396" font-size="18" fill="#dbe6f2">Plan</text>
       </g>
       <g>
-        <circle cx="644" cy="294" r="42" fill="#141c27" stroke="#f0a243" stroke-width="2"/>
-        <path d="M622 292l22-24 22 24-22 28zM622 292h44" fill="none" stroke="#f0a243" stroke-width="5" stroke-linejoin="round"/>
-        <text x="644" y="360" font-size="18" fill="#dbe6f2">Work</text>
+        <circle cx="644" cy="330" r="42" fill="#141c27" stroke="#f0a243" stroke-width="2"/>
+        <path d="M622 328l22-24 22 24-22 28zM622 328h44" fill="none" stroke="#f0a243" stroke-width="5" stroke-linejoin="round"/>
+        <text x="644" y="396" font-size="18" fill="#dbe6f2">Work</text>
       </g>
       <g>
-        <circle cx="814" cy="294" r="42" fill="#141c27" stroke="#ff6f91" stroke-width="2"/>
-        <path d="M794 297l13 13 29-38" fill="none" stroke="#ff6f91" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-        <text x="814" y="360" font-size="18" fill="#dbe6f2">Audit</text>
+        <circle cx="814" cy="330" r="42" fill="#141c27" stroke="#ff6f91" stroke-width="2"/>
+        <path d="M794 333l13 13 29-38" fill="none" stroke="#ff6f91" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+        <text x="814" y="396" font-size="18" fill="#dbe6f2">Audit</text>
       </g>
       <g>
-        <circle cx="984" cy="294" r="42" fill="#141c27" stroke="#35d4c9" stroke-width="2"/>
-        <path d="M964 295l14 14 31-40" fill="none" stroke="#35d4c9" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M958 321h52" stroke="#35d4c9" stroke-width="5" stroke-linecap="round"/>
-        <text x="984" y="360" font-size="18" fill="#dbe6f2">Proof</text>
+        <circle cx="984" cy="330" r="42" fill="#141c27" stroke="#35d4c9" stroke-width="2"/>
+        <path d="M964 331l14 14 31-40" fill="none" stroke="#35d4c9" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M958 357h52" stroke="#35d4c9" stroke-width="5" stroke-linecap="round"/>
+        <text x="984" y="396" font-size="18" fill="#dbe6f2">Proof</text>
       </g>
     </g>
 
-    <g transform="translate(78 408)">
+    <g transform="translate(78 436)">
       <text x="0" y="0" font-size="15" font-weight="800" fill="#8fa5bb">HOST-NEUTRAL ADAPTERS</text>
-      <g font-size="16" font-weight="700" fill="#eaf2fb">
-        <rect x="0" y="24" width="112" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="56" y="48" text-anchor="middle">Codex</text>
-        <rect x="124" y="24" width="136" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="192" y="48" text-anchor="middle">Claude Code</text>
-        <rect x="272" y="24" width="120" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="332" y="48" text-anchor="middle">OpenCode</text>
-        <rect x="0" y="70" width="112" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="56" y="94" text-anchor="middle">Hermes</text>
-        <rect x="124" y="70" width="126" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="187" y="94" text-anchor="middle">Qwen Code</text>
-        <rect x="262" y="70" width="104" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="314" y="94" text-anchor="middle">Goose</text>
-        <rect x="0" y="116" width="156" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="78" y="140" text-anchor="middle">OpenInterpreter</text>
-        <rect x="168" y="116" width="70" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="203" y="140" text-anchor="middle">Pi</text>
-        <rect x="250" y="116" width="122" height="36" rx="8" fill="#172231" stroke="#2d3d52"/>
-        <text x="311" y="140" text-anchor="middle">Grok Build</text>
+      <g font-size="14" font-weight="700" fill="#eaf2fb">
+        <rect x="0" y="22" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="61" y="43" text-anchor="middle">Codex</text>
+        <rect x="134" y="22" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="195" y="43" text-anchor="middle">Claude Code</text>
+        <rect x="268" y="22" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="329" y="43" text-anchor="middle">OpenCode</text>
+        <rect x="402" y="22" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="463" y="43" text-anchor="middle">Hermes</text>
+        <rect x="0" y="62" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="61" y="83" text-anchor="middle">Qwen Code</text>
+        <rect x="134" y="62" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="195" y="83" text-anchor="middle">Goose</text>
+        <rect x="268" y="62" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="329" y="83" text-anchor="middle">OpenInterpreter</text>
+        <rect x="402" y="62" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="463" y="83" text-anchor="middle">Pi</text>
+        <rect x="0" y="102" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="61" y="123" text-anchor="middle">Grok Build</text>
+        <rect x="134" y="102" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="195" y="123" text-anchor="middle">Cursor</text>
+        <rect x="268" y="102" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="329" y="123" text-anchor="middle">Gemini CLI</text>
+        <rect x="402" y="102" width="122" height="32" rx="8" fill="#172231" stroke="#2d3d52"/>
+        <text x="463" y="123" text-anchor="middle">Kimi Code</text>
       </g>
     </g>
 
-    <g transform="translate(724 398)">
-      <rect width="398" height="146" rx="16" fill="#111923" stroke="#2d3d52"/>
+    <g transform="translate(724 428)">
+      <rect width="398" height="136" rx="16" fill="#111923" stroke="#2d3d52"/>
       <text x="28" y="36" font-size="18" font-weight="800" fill="#ffffff">Built to finish</text>
       <g font-size="16" fill="#d7e2ee">
         <circle cx="34" cy="66" r="4" fill="#35d4c9"/>
-        <text x="50" y="72">Frozen plan before code</text>
+        <text x="50" y="72">SDD plan before code</text>
         <circle cx="34" cy="96" r="4" fill="#5eb4ff"/>
-        <text x="50" y="102">Receipts prove each step</text>
+        <text x="50" y="102">SDLC gates for agent work</text>
         <circle cx="34" cy="126" r="4" fill="#f0a243"/>
-        <text x="50" y="132">Light checks first, risk profiles on demand</text>
+        <text x="50" y="132">Deterministic packets and receipts</text>
       </g>
     </g>
 
-    <g transform="translate(78 568)">
-      <rect width="476" height="38" rx="10" fill="#111923" stroke="#2d3d52"/>
-      <text x="20" y="25" font-size="17" fill="#d7e2ee">github.com/avksp/agent-lifecycle-kit</text>
-    </g>
-    <text x="1120" y="594" text-anchor="end" font-size="20" font-weight="800" fill="#9cc9bd">Plan · Execute · Prove · Finish</text>
+    <text x="1120" y="594" text-anchor="end" font-size="20" font-weight="800" fill="#9cc9bd">SDD · SDLC · Deterministic proof</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- add more vertical spacing around the project title and lifecycle row
- arrange adapters in a four-column grid
- remove the repository link badge from the banner
- strengthen the value panel around SDD, SDLC gates, and deterministic proof

## Local-only note
- Telegram post text and generated PNG/SVG were updated under ignored `tasks/tg-post`, but are intentionally not part of this PR.

## Validation
- xmllint --noout docs/assets/agent-lifecycle-kit-banner.svg
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest tests.release.test_docs_gates -q
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 tools/release/validate_docs_compat.py --evidence work/banner-spacing-copy/evidence/docs-compat.json
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest discover -s tests -q
- git diff --check
