### PR TITLE
docs: add code review workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ and usage export details are listed in [Public contracts](docs/reference/public-
 
 ## Documentation
 
-- Start: [English documentation](docs/README.md), [Русская документация](docs/ru/README.md), and [Quickstart](docs/guides/quickstart.md).
+- Start: [English documentation](docs/README.md), [Русская документация](docs/ru/README.md), [Quickstart](docs/guides/quickstart.md), and [Code review workflows](docs/guides/code-review-workflows.md).
 - Planning and adapters: [Issue to specification drafts](docs/guides/issue-to-spec.md), [Adapter install](docs/adapters/install.md), and [Adapter support matrix](docs/adapters/support-matrix.md).
 - Reference: [CLI reference](docs/reference/cli.md), [Source of truth](docs/reference/source-of-truth.md), [Managed lifecycle runner](docs/reference/managed-lifecycle-runner.md), [Managed adapter sessions](docs/reference/managed-adapter-sessions.md), [Implementation audit](docs/reference/implementation-audit.md), [Plan completeness](docs/reference/plan-completeness.md), [Public contracts](docs/reference/public-contracts.md), and [Readiness diagnostics](docs/reference/readiness-diagnostics.md).
 - Quality and resources: [Small-model packets](docs/reference/small-model-packets.md), [model routing](docs/reference/model-routing.md), [adaptive policy](docs/reference/adaptive-lifecycle-policy.md), [quality-cost learning](docs/reference/quality-cost-learning.md), [lifecycle cost accounting](docs/reference/lifecycle-cost.md), [Usage export](docs/reference/usage-export.md), and [Evidence integrity](docs/reference/evidence-integrity.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ project.
 - [Pi adapter](adapters/pi.md)
 - [Qwen Code adapter](adapters/qwen-code.md)
 - [Quickstart](guides/quickstart.md)
+- [Code review workflows](guides/code-review-workflows.md)
 - [Review Mesh workflow cookbook](guides/review-mesh-workflow.md)
 - [Issue to specification drafts](guides/issue-to-spec.md)
 - [Offline source-release checks](guides/release-candidate.md)

--- a/docs/guides/code-review-workflows.md
+++ b/docs/guides/code-review-workflows.md
@@ -1,0 +1,410 @@
+# Code review workflows
+
+Use ALK for code review when the important question is not only "does the diff
+look good?", but whether the change fits the task, architecture, evidence and
+release boundary. ALK can review a local diff, a GitHub pull request, a GitLab
+merge request, a Markdown plan package, or a completed implementation attempt.
+
+ALK does not need to own GitHub or GitLab access. Prepare the diff and task
+context with normal Git or host CLI commands, then pass one Markdown task file
+to `adapter task start`. Raw text and Markdown stay review-gated: they do not
+authorize implementation.
+
+## Choose the review path
+
+| Case | Use this path | Main commands |
+| --- | --- | --- |
+| Architecture is documented | Review the diff against known architecture and contracts. | `adapter task start`, optional `review-mesh recommend` |
+| Architecture is not documented | First recover architecture boundaries, then review the diff. | `adapter task start`, `review-mesh recommend` |
+| GitHub pull request | Check out or fetch the PR, save a diff, review that packet. | `gh pr checkout` or `git fetch`, then `adapter task start` |
+| GitLab merge request | Fetch the MR branch, save a diff, review that packet. | `git fetch`, then `adapter task start` |
+| Plan package only | Review Markdown plan files without implementation. | `adapter task start`, `review-mesh recommend` |
+| Completed ALK task | Audit the result against the frozen plan and evidence. | `audit implementation` |
+| High-risk review | Coordinate more than one reviewer and require quorum only if the frozen plan opts in. | `review-mesh assign/import-result/synthesize/quorum` |
+
+## Prepare a review packet
+
+Keep the review packet explicit. Put the task, diff path, architecture links,
+risk focus and output format in one Markdown file.
+
+```bash
+mkdir -p work/code-review/pr-123
+```
+
+Example task file:
+
+```markdown
+# Task
+
+Review the change in `work/code-review/pr-123/diff.patch`.
+Do not implement.
+
+Architecture and contracts:
+- docs/architecture.md
+- docs/reference/public-contracts.md
+
+Check:
+- architecture fit and module boundaries;
+- logic errors and edge cases;
+- security and data handling;
+- SOLID, DRY and KISS;
+- test coverage and missing evidence;
+- migration, compatibility and release risk.
+
+Return:
+- findings ordered by severity;
+- merge blockers;
+- optional follow-up items;
+- required validation commands.
+```
+
+Start the ALK intake:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/pr-123/review-task.md \
+  --out work/code-review/pr-123/intake.json
+```
+
+Ask whether several reviewers are useful:
+
+```bash
+agent-lifecycle review-mesh recommend \
+  --intake work/code-review/pr-123/intake.json \
+  --out work/code-review/pr-123/recommendation.json
+```
+
+The recommendation is advisory until a reviewed frozen plan explicitly requires
+it.
+
+## Review a GitHub pull request
+
+If GitHub CLI is available:
+
+```bash
+gh pr checkout 123
+mkdir -p work/code-review/pr-123
+git diff origin/main...HEAD > work/code-review/pr-123/diff.patch
+```
+
+Without GitHub CLI:
+
+```bash
+git fetch origin pull/123/head:review/pr-123
+mkdir -p work/code-review/pr-123
+git diff origin/main...review/pr-123 > work/code-review/pr-123/diff.patch
+```
+
+Then create `work/code-review/pr-123/review-task.md` and run:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/pr-123/review-task.md \
+  --out work/code-review/pr-123/intake.json
+```
+
+Use this for normal PR review, architecture review, security review, or
+pre-merge risk review. Do not include secrets or private environment values in
+the task file.
+
+## Review a GitLab merge request
+
+Fetch the merge request branch and build the same kind of packet:
+
+```bash
+git fetch origin merge-requests/45/head:review/mr-45
+mkdir -p work/code-review/mr-45
+git diff origin/main...review/mr-45 > work/code-review/mr-45/diff.patch
+```
+
+Create `work/code-review/mr-45/review-task.md`:
+
+```markdown
+# Task
+
+Review GitLab merge request 45 using `work/code-review/mr-45/diff.patch`.
+Do not implement.
+
+Check architecture fit, defects, security, tests, ownership and release risk.
+Return findings first, then a merge verdict.
+```
+
+Run intake and recommendation:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/mr-45/review-task.md \
+  --out work/code-review/mr-45/intake.json
+
+agent-lifecycle review-mesh recommend \
+  --intake work/code-review/mr-45/intake.json \
+  --out work/code-review/mr-45/recommendation.json
+```
+
+Some GitLab installations use different protected branch names or refspecs.
+That is outside ALK; the review packet only needs a stable diff and clear task
+context.
+
+## Review when architecture is documented
+
+When architecture exists, make it the source of truth for the review:
+
+```markdown
+# Task
+
+Review `work/code-review/pr-123/diff.patch` against the documented architecture.
+Do not implement.
+
+Architecture:
+- docs/architecture/modular-controller.md
+- docs/reference/source-of-truth.md
+- docs/reference/public-contracts.md
+
+Focus:
+- whether the changed files belong to the right layer;
+- whether new abstractions are justified;
+- whether contracts remain additive;
+- whether tests prove the intended behavior;
+- whether release or adapter claims were broadened.
+```
+
+This path is best for architecture-sensitive code, public contracts, adapters,
+security boundaries, migration code and release work.
+
+## Review when architecture is missing
+
+If architecture is not documented, do not pretend the reviewer already knows
+the boundaries. Ask for architecture discovery first:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --text "Analyze the repository and the diff in work/code-review/pr-123/diff.patch. First recover the module responsibilities and architecture boundaries, then review the diff against that recovered map. Do not implement." \
+  --out work/code-review/pr-123/intake.json
+```
+
+Expected output:
+
+- a compact architecture map;
+- uncertain assumptions;
+- review findings;
+- missing tests or evidence;
+- whether a formal plan should be created before implementation.
+
+For larger or risky changes, use `parallel-research-synthesis` so reviewers can
+independently recover architecture and then compare conclusions.
+
+## Review a Markdown plan package
+
+For a plan split across several Markdown files, either point reviewers at the
+directory or combine files into one packet.
+
+Repository-local review:
+
+```bash
+cat > work/code-review/plan-review-task.md <<'EOF'
+# Task
+
+Review the Markdown plan package in `tasks/release-1-40/`.
+Read every `.md` file in that directory.
+Do not implement.
+
+Check requirements, acceptance criteria, evidence routes, write ownership,
+security gates and release claims.
+EOF
+
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/plan-review-task.md \
+  --out work/code-review/plan-intake.json
+```
+
+Portable packet:
+
+```bash
+mkdir -p work/code-review
+{
+  printf '# Task\n\n'
+  printf 'Review the combined Markdown plan package. Do not implement.\n\n'
+  find tasks/release-1-40 -maxdepth 1 -name '*.md' -print | sort | while IFS= read -r file; do
+    printf '\n\n---\n\n## %s\n\n' "$file"
+    cat "$file"
+  done
+} > work/code-review/plan-review-input.md
+
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/plan-review-input.md \
+  --out work/code-review/plan-intake.json
+```
+
+## Coordinate several reviewers
+
+Create a profile:
+
+```bash
+agent-lifecycle review-mesh profile \
+  --profile-id rm-code-review \
+  --default-mode leader-draft-multi-review \
+  --reviewer-model-class strong-reasoning \
+  --reviewer-model-class local-strong-review \
+  --max-invocations 3 \
+  --max-input-tokens 12000 \
+  --max-output-tokens 3000 \
+  --max-wall-seconds 900 \
+  --out work/code-review/rm-profile.json
+```
+
+Create assignments:
+
+```bash
+agent-lifecycle review-mesh assign \
+  --intake work/code-review/pr-123/intake.json \
+  --profile work/code-review/rm-profile.json \
+  --mode leader-draft-multi-review \
+  --phase plan-review \
+  --assignment-id RM-CODEX \
+  --reviewer-id codex-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-model-class strong-reasoning \
+  --out work/code-review/rm-codex.json
+
+agent-lifecycle review-mesh assign \
+  --intake work/code-review/pr-123/intake.json \
+  --profile work/code-review/rm-profile.json \
+  --mode leader-draft-multi-review \
+  --phase plan-review \
+  --assignment-id RM-CLAUDE \
+  --reviewer-id claude-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-model-class strong-reasoning \
+  --out work/code-review/rm-claude.json
+
+agent-lifecycle review-mesh assign \
+  --intake work/code-review/pr-123/intake.json \
+  --profile work/code-review/rm-profile.json \
+  --mode leader-draft-multi-review \
+  --phase plan-review \
+  --assignment-id RM-OPENCODE \
+  --reviewer-id opencode-glm-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-model-class strong-reasoning \
+  --out work/code-review/rm-opencode.json
+```
+
+Run reviewers outside ALK. These commands are examples; replace the model ids
+with the models configured for your host:
+
+```bash
+codex exec --model <codex-model-id> \
+  "Review work/code-review/rm-codex.json and return only reviewer-output.v1 JSON" \
+  > work/code-review/codex-output.json
+
+claude --model <claude-model-alias> --print --output-format json \
+  "Review work/code-review/rm-claude.json and return only reviewer-output.v1 JSON" \
+  > work/code-review/claude-output.json
+
+opencode run --model <provider>/<model-id> --format json \
+  --file work/code-review/rm-opencode.json \
+  "Review the assignment and return only reviewer-output.v1 JSON" \
+  > work/code-review/opencode-output.json
+```
+
+For OpenCode, `<provider>/<model-id>` can point to GLM or any other configured
+model. ALK keeps the portable contract provider-neutral; concrete model choice
+stays in the host command or host-local configuration.
+
+Each reviewer returns a small JSON object:
+
+```json
+{
+  "schemaVersion": "reviewer-output.v1",
+  "status": "FAIL",
+  "budgetUsage": {
+    "invocations": 1,
+    "inputTokens": 9000,
+    "outputTokens": 1400,
+    "wallSeconds": 360
+  },
+  "findings": [
+    {
+      "id": "CR-1",
+      "severity": "MEDIUM",
+      "status": "open",
+      "message": "The diff changes the session boundary without a regression test."
+    }
+  ]
+}
+```
+
+Import and combine reviewer output:
+
+```bash
+agent-lifecycle review-mesh import-result \
+  --profile work/code-review/rm-profile.json \
+  --assignment work/code-review/rm-codex.json \
+  --reviewer-output work/code-review/codex-output.json \
+  --out work/code-review/rm-result-codex.json
+
+agent-lifecycle review-mesh import-result \
+  --profile work/code-review/rm-profile.json \
+  --assignment work/code-review/rm-claude.json \
+  --reviewer-output work/code-review/claude-output.json \
+  --out work/code-review/rm-result-claude.json
+
+agent-lifecycle review-mesh import-result \
+  --profile work/code-review/rm-profile.json \
+  --assignment work/code-review/rm-opencode.json \
+  --reviewer-output work/code-review/opencode-output.json \
+  --out work/code-review/rm-result-opencode.json
+
+agent-lifecycle review-mesh synthesize \
+  --profile work/code-review/rm-profile.json \
+  --result work/code-review/rm-result-codex.json \
+  --result work/code-review/rm-result-claude.json \
+  --result work/code-review/rm-result-opencode.json \
+  --out work/code-review/rm-synthesis.json
+
+agent-lifecycle review-mesh quorum \
+  --profile work/code-review/rm-profile.json \
+  --synthesis work/code-review/rm-synthesis.json \
+  --min-reviewers 2 \
+  --required-role code-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-role code-reviewer \
+  --out work/code-review/rm-quorum.json
+```
+
+## Audit an ALK implementation
+
+When the reviewed change was produced by a frozen ALK plan, use the
+implementation audit command instead of a plain diff review:
+
+```bash
+agent-lifecycle audit implementation \
+  --manifest tasks/release-x/plan.manifest.json \
+  --state work/run.state.json \
+  --task WS-01 \
+  --result work/WS-01/attempt-1/task-result.json \
+  --review work/WS-01/attempt-1/task-review.json \
+  --review-mesh-quorum work/code-review/rm-quorum.json \
+  --out work/WS-01/attempt-1/implementation-audit.json
+```
+
+Use `--review-mesh-quorum` only when the frozen plan requires several reviewers
+for that phase. Otherwise a normal independent task review is enough.
+
+## Safety checklist
+
+- Keep raw tokens, API keys and private environment files out of task files and
+  reviewer output.
+- Prefer relative repository paths in portable review packets.
+- Use `--allow-local-evidence-ref` only when the frozen plan explicitly allows
+  local evidence references.
+- Treat `review-mesh recommend` as advice until a frozen plan opts in.
+- Do not merge on a self-review. High-risk changes need independent review or
+  a recorded quorum receipt.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -70,6 +70,33 @@ This does not start implementation for raw input. It returns a review-gated
 draft receipt. Managed execution requires a frozen run request or a frozen plan
 with workflow binding.
 
+## Review code changes
+
+For a local branch, GitHub pull request or GitLab merge request, first prepare a
+diff and a short review task:
+
+```bash
+mkdir -p work/code-review/current
+git diff origin/main...HEAD > work/code-review/current/diff.patch
+```
+
+Then pass the task to ALK without starting implementation:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/current/review-task.md \
+  --out work/code-review/current/intake.json
+
+agent-lifecycle review-mesh recommend \
+  --intake work/code-review/current/intake.json \
+  --out work/code-review/current/recommendation.json
+```
+
+Use this for ordinary diff review, architecture review, security review and
+pre-merge risk review. Full GitHub, GitLab, architecture and implementation
+audit examples are in [Code review workflows](code-review-workflows.md).
+
 ## Optional multi-review advice
 
 For research, planning or audit-heavy work, ask for a local Review Mesh

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -18,6 +18,19 @@ OpenInterpreter, Pi, Grok Build и других. Ядро не зависит о
 
 **Лицензия:** Apache-2.0 · **Версия:** 1.42.0 · **Python:** 3.11-3.13
 
+## Быстрый старт
+
+Из исходного дерева:
+
+```bash
+python -m pip install -e .
+agent-lifecycle version
+agent-lifecycle diagnose --no-install-plans
+agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.json
+```
+
+Пошаговый пример: [Быстрый старт](quickstart.md).
+
 ## Что даёт ALK
 
 - Процесс ориентирован на результат: план, выполнение, проверка и подтверждение
@@ -106,19 +119,6 @@ OpenInterpreter, Pi, Grok Build и других. Ядро не зависит о
   активности.
 - Диагностика готовности, лента событий, управляемый шаг, наблюдение за прогрессом и счётчик изменений не меняют состояние и не запускают модель.
 
-## Быстрый старт
-
-Из исходного дерева:
-
-```bash
-python -m pip install -e .
-agent-lifecycle version
-agent-lifecycle diagnose --no-install-plans
-agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.json
-```
-
-Пошаговый пример: [Быстрый старт](quickstart.md).
-
 ## Обычный цикл
 
 Обычный путь: спецификация -> зафиксированный план -> работа в заданных
@@ -183,7 +183,7 @@ agent-lifecycle adapter validate --descriptor adapters/codex/adapter.descriptor.
 
 ## Документы
 
-- Старт: [Быстрый старт](quickstart.md), [практические сценарии групповой проверки](review-mesh-workflow.md) и [черновик спецификации из issue](issue-to-spec.md).
+- Старт: [Быстрый старт](quickstart.md), [сценарии проверки кода](code-review-workflows.md), [практические сценарии групповой проверки](review-mesh-workflow.md) и [черновик спецификации из issue](issue-to-spec.md).
 - Адаптеры: [Установка](adapters/install.md), [поддержка](adapters/support-matrix.md), [управляемые сессии](adapters/managed-session-support.md), [прогресс](adapters/progress-bridge-matrix.md), [создание адаптера](adapters/authoring.md), [порядок перевода в VERIFIED](adapters/live-promotion-runbook.md), [Codex](adapters/codex.md), [Claude Code](adapters/claude.md), [Cursor](adapters/cursor.md), [Gemini CLI](adapters/gemini-cli.md), [Goose](adapters/goose.md), [Grok Build](adapters/grok-build.md), [Hermes](adapters/hermes.md), [Kimi Code](adapters/kimi-code.md), [OpenCode](adapters/opencode.md), [OpenInterpreter](adapters/openinterpreter.md), [Pi](adapters/pi.md) и [Qwen Code](adapters/qwen-code.md).
 - Основной справочник: [Команды CLI](reference/cli.md), [источник правды](reference/source-of-truth.md), [управляемый шаг жизненного цикла](reference/managed-lifecycle-runner.md), [управляемые сессии адаптеров](reference/managed-adapter-sessions.md), [аудит реализации](reference/implementation-audit.md), [полнота плана](reference/plan-completeness.md), [публикация плагинов](reference/plugin-publication.md), [публичные контракты](reference/public-contracts.md), [диагностика готовности](reference/readiness-diagnostics.md), [компактные пакеты](reference/small-model-packets.md), [адаптивные правила](reference/adaptive-lifecycle-policy.md), [локальная статистика](reference/quality-cost-learning.md), [учёт расхода](reference/lifecycle-cost.md), [экспорт использования](reference/usage-export.md), [целостность подтверждений](reference/evidence-integrity.md), [границы песочницы](reference/sandbox-boundaries.md) и [безопасность релиза](security/release-security.md).
 - Дополнительный справочник: [статус без записи](reference/read-only-status-view.md), [прогресс](reference/automatic-progress-bridge.md), [индекс подтверждений и импорт](reference/evidence-imports.md), [импорт внешних форматов](reference/import-mappers.md), [эпизоды](reference/episode-retrieval.md), [восстановление](reference/runner-recovery.md), [перепроверка](reference/cross-check-profile.md), [групповая проверка](reference/review-mesh.md), [рекомендация групповой проверки](reference/review-mesh.md#рекомендация-режима), [профиль расследования ошибок](reference/bug-forensics.md), [бюджет контекста для него](reference/bug-forensics-context-budget.md), [проверка завершения](reference/completion-check.md), [непрерывность цели](reference/goal-continuity.md), [реестр отложенной работы](reference/follow-up-register.md), [изоляция рабочего дерева](reference/worktree-isolation.md), [возможности хоста](reference/host-capabilities.md), [захват событий адаптера](reference/adapter-event-capture.md), [вердикт проверки](reference/review-verdict.md), [дополнительные пакеты качества](reference/optional-quality-packs.md), [маршрутизация моделей](reference/model-routing.md), [предложения правил](reference/policy.md), [промышленная готовность](reference/production-promotion.md), [калибровка реального расхода](reference/live-cost-calibration.md), [непрерывность плана](reference/plan-continuity.md), [диагностические пакеты](reference/diagnostic-bundles.md), [контролируемый запуск](reference/runner.md) и [шаблоны задач](reference/task-templates.md).

--- a/docs/ru/code-review-workflows.md
+++ b/docs/ru/code-review-workflows.md
@@ -1,0 +1,415 @@
+# Сценарии проверки кода
+
+Используйте ALK для проверки кода, когда важно не только посмотреть файл изменений, но и
+понять, соответствует ли изменение задаче, архитектуре, подтверждениям и
+границам релиза. ALK подходит для локального файла изменений, запроса на
+слияние в GitHub, запроса на слияние в GitLab, пакета Markdown с планом и результата задачи,
+выполненной по зафиксированному плану.
+
+ALK не обязан сам подключаться к GitHub или GitLab. Подготовьте файл изменений и контекст
+обычными командами Git или CLI хоста, затем передайте один Markdown-файл в
+`adapter task start`. Обычный текст и Markdown остаются черновым входом для
+проверки: они не разрешают реализацию.
+
+## Как выбрать путь
+
+| Случай | Что делать | Основные команды |
+| --- | --- | --- |
+| Архитектура описана | Проверить файл изменений против архитектуры и контрактов. | `adapter task start`, при необходимости `review-mesh recommend` |
+| Архитектура не описана | Сначала восстановить границы архитектуры, затем проверить файл изменений. | `adapter task start`, `review-mesh recommend` |
+| Запрос на слияние в GitHub | Получить ветку PR, сохранить файл изменений, проверить этот пакет. | `gh pr checkout` или `git fetch`, затем `adapter task start` |
+| Запрос на слияние в GitLab | Получить ветку MR, сохранить файл изменений, проверить этот пакет. | `git fetch`, затем `adapter task start` |
+| Только пакет плана | Проверить Markdown-файлы плана без реализации. | `adapter task start`, `review-mesh recommend` |
+| Завершённая задача ALK | Проверить результат против зафиксированного плана и подтверждений. | `audit implementation` |
+| Высокий риск | Подключить несколько проверяющих; кворум делать обязательным только через зафиксированный план. | `review-mesh assign/import-result/synthesize/quorum` |
+
+## Подготовка пакета проверки
+
+Пакет должен быть явным. В одном Markdown-файле укажите задачу, путь к файлу изменений,
+ссылки на архитектуру, область риска и формат результата.
+
+```bash
+mkdir -p work/code-review/pr-123
+```
+
+Пример файла задачи:
+
+```markdown
+# Задача
+
+Проведи проверку изменений из `work/code-review/pr-123/diff.patch`.
+Реализацию не начинать.
+
+Архитектура и контракты:
+- docs/architecture.md
+- docs/reference/public-contracts.md
+
+Проверить:
+- соответствие архитектуре и границы модулей;
+- ошибки логики и крайние случаи;
+- безопасность и обработку данных;
+- SOLID, DRY и KISS;
+- полноту тестов и недостающие подтверждения;
+- риски миграций, совместимости и релиза.
+
+Результат:
+- находки по уровню серьёзности;
+- что блокирует слияние;
+- что можно вынести в последующую задачу;
+- какие проверки нужно выполнить.
+```
+
+Передайте задачу в ALK:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/pr-123/review-task.md \
+  --out work/code-review/pr-123/intake.json
+```
+
+Проверьте, нужна ли группа проверяющих:
+
+```bash
+agent-lifecycle review-mesh recommend \
+  --intake work/code-review/pr-123/intake.json \
+  --out work/code-review/pr-123/recommendation.json
+```
+
+Рекомендация остаётся советом, пока проверенный зафиксированный план явно не
+требует такую проверку.
+
+## Проверка запроса на слияние в GitHub
+
+Если установлен GitHub CLI:
+
+```bash
+gh pr checkout 123
+mkdir -p work/code-review/pr-123
+git diff origin/main...HEAD > work/code-review/pr-123/diff.patch
+```
+
+Без GitHub CLI:
+
+```bash
+git fetch origin pull/123/head:review/pr-123
+mkdir -p work/code-review/pr-123
+git diff origin/main...review/pr-123 > work/code-review/pr-123/diff.patch
+```
+
+Затем создайте `work/code-review/pr-123/review-task.md` и запустите:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/pr-123/review-task.md \
+  --out work/code-review/pr-123/intake.json
+```
+
+Такой путь подходит для обычной проверки PR, архитектурной проверки, проверки
+безопасности и оценки риска перед слиянием. Не добавляйте в файл задачи секреты и
+значения приватных переменных окружения.
+
+## Проверка запроса на слияние в GitLab
+
+Получите ветку MR и подготовьте такой же пакет:
+
+```bash
+git fetch origin merge-requests/45/head:review/mr-45
+mkdir -p work/code-review/mr-45
+git diff origin/main...review/mr-45 > work/code-review/mr-45/diff.patch
+```
+
+Создайте `work/code-review/mr-45/review-task.md`:
+
+```markdown
+# Задача
+
+Проведи проверку запроса на слияние GitLab 45 по файлу
+`work/code-review/mr-45/diff.patch`. Реализацию не начинать.
+
+Проверить архитектуру, дефекты, безопасность, тесты, владение файлами и
+релизный риск. Сначала вернуть находки, затем итоговый вердикт по слиянию.
+```
+
+Запустите приём задачи и рекомендацию:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/mr-45/review-task.md \
+  --out work/code-review/mr-45/intake.json
+
+agent-lifecycle review-mesh recommend \
+  --intake work/code-review/mr-45/intake.json \
+  --out work/code-review/mr-45/recommendation.json
+```
+
+В некоторых установках GitLab могут отличаться имя основной ветки или refspec.
+Это остаётся вне ALK; для проверки нужен стабильный файл изменений и понятный контекст
+задачи.
+
+## Если архитектура описана
+
+Когда архитектура есть, сделайте её источником правды для проверки:
+
+```markdown
+# Задача
+
+Проведи проверку `work/code-review/pr-123/diff.patch` против описанной
+архитектуры. Реализацию не начинать.
+
+Архитектура:
+- docs/architecture/modular-controller.md
+- docs/reference/source-of-truth.md
+- docs/reference/public-contracts.md
+
+Фокус:
+- изменены ли файлы правильного слоя;
+- оправданы ли новые абстракции;
+- остаются ли контракты совместимыми;
+- доказывают ли тесты нужное поведение;
+- не расширены ли заявления релиза или адаптеров.
+```
+
+Такой путь лучше использовать для кода, который затрагивает архитектуру,
+публичные контракты, адаптеры, безопасность, миграции и релизы.
+
+## Если архитектура не описана
+
+Если архитектура не описана, не нужно делать вид, что проверяющий уже знает
+границы системы. Сначала запросите восстановление архитектурной картины:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --text "Проанализируй репозиторий и файл изменений work/code-review/pr-123/diff.patch. Сначала восстанови ответственность модулей и границы архитектуры, затем проверь изменение относительно этой картины. Реализацию не начинать." \
+  --out work/code-review/pr-123/intake.json
+```
+
+Ожидаемый результат:
+
+- краткая карта архитектуры;
+- спорные или непроверенные предположения;
+- находки по изменению;
+- недостающие тесты или подтверждения;
+- нужна ли формальная подготовка плана до реализации.
+
+Для больших или рискованных изменений полезен режим параллельного исследования:
+несколько проверяющих независимо восстанавливают архитектуру, а затем ALK
+объединяет выводы.
+
+## Проверка Markdown-пакета плана
+
+Если план разложен по нескольким Markdown-файлам, можно дать ссылку на папку
+или собрать файлы в один входной пакет.
+
+Проверка внутри того же репозитория:
+
+```bash
+cat > work/code-review/plan-review-task.md <<'EOF'
+# Задача
+
+Проверь Markdown-пакет плана в `tasks/release-1-40/`.
+Прочитай все `.md` файлы в этой папке.
+Реализацию не начинать.
+
+Проверить требования, критерии приёмки, маршруты подтверждений, владение
+файлами, проверки безопасности и релизные заявления.
+EOF
+
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/plan-review-task.md \
+  --out work/code-review/plan-intake.json
+```
+
+Переносимый пакет:
+
+```bash
+mkdir -p work/code-review
+{
+  printf '# Задача\n\n'
+  printf 'Проверь объединённый Markdown-пакет плана. Реализацию не начинать.\n\n'
+  find tasks/release-1-40 -maxdepth 1 -name '*.md' -print | sort | while IFS= read -r file; do
+    printf '\n\n---\n\n## %s\n\n' "$file"
+    cat "$file"
+  done
+} > work/code-review/plan-review-input.md
+
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/plan-review-input.md \
+  --out work/code-review/plan-intake.json
+```
+
+## Несколько проверяющих
+
+Создайте профиль:
+
+```bash
+agent-lifecycle review-mesh profile \
+  --profile-id rm-code-review \
+  --default-mode leader-draft-multi-review \
+  --reviewer-model-class strong-reasoning \
+  --reviewer-model-class local-strong-review \
+  --max-invocations 3 \
+  --max-input-tokens 12000 \
+  --max-output-tokens 3000 \
+  --max-wall-seconds 900 \
+  --out work/code-review/rm-profile.json
+```
+
+Создайте назначения:
+
+```bash
+agent-lifecycle review-mesh assign \
+  --intake work/code-review/pr-123/intake.json \
+  --profile work/code-review/rm-profile.json \
+  --mode leader-draft-multi-review \
+  --phase plan-review \
+  --assignment-id RM-CODEX \
+  --reviewer-id codex-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-model-class strong-reasoning \
+  --out work/code-review/rm-codex.json
+
+agent-lifecycle review-mesh assign \
+  --intake work/code-review/pr-123/intake.json \
+  --profile work/code-review/rm-profile.json \
+  --mode leader-draft-multi-review \
+  --phase plan-review \
+  --assignment-id RM-CLAUDE \
+  --reviewer-id claude-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-model-class strong-reasoning \
+  --out work/code-review/rm-claude.json
+
+agent-lifecycle review-mesh assign \
+  --intake work/code-review/pr-123/intake.json \
+  --profile work/code-review/rm-profile.json \
+  --mode leader-draft-multi-review \
+  --phase plan-review \
+  --assignment-id RM-OPENCODE \
+  --reviewer-id opencode-glm-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-model-class strong-reasoning \
+  --out work/code-review/rm-opencode.json
+```
+
+Запустите проверяющих вне ALK. Команды ниже являются примерами; замените
+идентификаторы моделей на те, которые настроены в вашем CLI:
+
+```bash
+codex exec --model <codex-model-id> \
+  "Проверь work/code-review/rm-codex.json и верни только JSON reviewer-output.v1" \
+  > work/code-review/codex-output.json
+
+claude --model <claude-model-alias> --print --output-format json \
+  "Проверь work/code-review/rm-claude.json и верни только JSON reviewer-output.v1" \
+  > work/code-review/claude-output.json
+
+opencode run --model <provider>/<model-id> --format json \
+  --file work/code-review/rm-opencode.json \
+  "Проверь назначение и верни только JSON reviewer-output.v1" \
+  > work/code-review/opencode-output.json
+```
+
+Для OpenCode `<provider>/<model-id>` может указывать на GLM или любую другую
+настроенную модель. ALK оставляет переносимый контракт независимым от
+провайдера; конкретная модель выбирается командой хоста или локальной
+настройкой хоста.
+
+Каждый проверяющий возвращает небольшой JSON:
+
+```json
+{
+  "schemaVersion": "reviewer-output.v1",
+  "status": "FAIL",
+  "budgetUsage": {
+    "invocations": 1,
+    "inputTokens": 9000,
+    "outputTokens": 1400,
+    "wallSeconds": 360
+  },
+  "findings": [
+    {
+      "id": "CR-1",
+      "severity": "MEDIUM",
+      "status": "open",
+      "message": "Изменение затрагивает границу сессии без регрессионного теста."
+    }
+  ]
+}
+```
+
+Импортируйте и объедините результаты:
+
+```bash
+agent-lifecycle review-mesh import-result \
+  --profile work/code-review/rm-profile.json \
+  --assignment work/code-review/rm-codex.json \
+  --reviewer-output work/code-review/codex-output.json \
+  --out work/code-review/rm-result-codex.json
+
+agent-lifecycle review-mesh import-result \
+  --profile work/code-review/rm-profile.json \
+  --assignment work/code-review/rm-claude.json \
+  --reviewer-output work/code-review/claude-output.json \
+  --out work/code-review/rm-result-claude.json
+
+agent-lifecycle review-mesh import-result \
+  --profile work/code-review/rm-profile.json \
+  --assignment work/code-review/rm-opencode.json \
+  --reviewer-output work/code-review/opencode-output.json \
+  --out work/code-review/rm-result-opencode.json
+
+agent-lifecycle review-mesh synthesize \
+  --profile work/code-review/rm-profile.json \
+  --result work/code-review/rm-result-codex.json \
+  --result work/code-review/rm-result-claude.json \
+  --result work/code-review/rm-result-opencode.json \
+  --out work/code-review/rm-synthesis.json
+
+agent-lifecycle review-mesh quorum \
+  --profile work/code-review/rm-profile.json \
+  --synthesis work/code-review/rm-synthesis.json \
+  --min-reviewers 2 \
+  --required-role code-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-role code-reviewer \
+  --reviewer-role code-reviewer \
+  --out work/code-review/rm-quorum.json
+```
+
+## Аудит реализации ALK
+
+Если изменение было сделано по зафиксированному плану ALK, используйте аудит
+реализации вместо обычной проверки файла изменений:
+
+```bash
+agent-lifecycle audit implementation \
+  --manifest tasks/release-x/plan.manifest.json \
+  --state work/run.state.json \
+  --task WS-01 \
+  --result work/WS-01/attempt-1/task-result.json \
+  --review work/WS-01/attempt-1/task-review.json \
+  --review-mesh-quorum work/code-review/rm-quorum.json \
+  --out work/WS-01/attempt-1/implementation-audit.json
+```
+
+Используйте `--review-mesh-quorum` только если зафиксированный план требует
+нескольких проверяющих на этом этапе. В остальных случаях достаточно обычной
+независимой проверки задачи.
+
+## Правила безопасности
+
+- Не добавляйте в файлы задачи и вывод проверяющих токены, API-ключи и
+  приватные файлы окружения.
+- В переносимых пакетах проверки используйте относительные пути репозитория.
+- Используйте `--allow-local-evidence-ref` только если зафиксированный план
+  явно разрешает ссылки на локальные подтверждения.
+- Считайте `review-mesh recommend` советом, пока зафиксированный план явно не
+  включил этот режим.
+- Не принимайте изменение по самопроверке. Для рискованных изменений нужна
+  независимая проверка или зафиксированное подтверждение кворума.

--- a/docs/ru/quickstart.md
+++ b/docs/ru/quickstart.md
@@ -71,6 +71,34 @@ agent-lifecycle adapter task start --adapter codex --text "Исправь пад
 зафиксированного запроса запуска или зафиксированного плана с привязкой к
 рабочему циклу.
 
+## Проверка изменений
+
+Для локальной ветки, запроса на слияние в GitHub или запроса на слияние в
+GitLab сначала подготовьте файл изменений и короткую задачу проверки:
+
+```bash
+mkdir -p work/code-review/current
+git diff origin/main...HEAD > work/code-review/current/diff.patch
+```
+
+Затем передайте задачу в ALK без запуска реализации:
+
+```bash
+agent-lifecycle adapter task start \
+  --adapter codex \
+  --file work/code-review/current/review-task.md \
+  --out work/code-review/current/intake.json
+
+agent-lifecycle review-mesh recommend \
+  --intake work/code-review/current/intake.json \
+  --out work/code-review/current/recommendation.json
+```
+
+Используйте этот путь для обычной проверки файла изменений, архитектурной проверки,
+проверки безопасности и оценки риска перед слиянием. Подробные примеры для
+GitHub, GitLab, архитектуры и аудита реализации:
+[сценарии проверки кода](code-review-workflows.md).
+
 ## Дополнительная перепроверка
 
 Для исследования, планирования или сложного аудита можно сначала получить
@@ -101,5 +129,6 @@ agent-lifecycle context check \
 ## Что дальше
 
 - [Установка адаптеров](adapters/install.md)
+- [Сценарии проверки кода](code-review-workflows.md)
 - [Справочник команд](reference/cli.md)
 - [Диагностика готовности](reference/readiness-diagnostics.md)

--- a/tests/release/test_docs_gates.py
+++ b/tests/release/test_docs_gates.py
@@ -46,10 +46,12 @@ class ReleaseDocumentationGateTests(unittest.TestCase):
         for relative in (
             "README.md",
             "docs/README.md",
+            "docs/guides/code-review-workflows.md",
             "docs/guides/README.ru.md",
             "docs/guides/quickstart.md",
             "docs/guides/quickstart.ru.md",
             "docs/ru/README.md",
+            "docs/ru/code-review-workflows.md",
             "docs/ru/quickstart.md",
             "docs/ru/adapters/install.md",
             "docs/ru/adapters/progress-bridge-matrix.md",


### PR DESCRIPTION
## Summary
- add English and Russian code review workflow guides for local diffs, GitHub PRs, GitLab MRs, architecture-aware reviews, plan-package reviews, multi-reviewer checks, and implementation audits
- link the new guide from README indexes and quickstarts
- include the new guide pages in docs link gates

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m unittest tests.release.test_docs_gates -q
- PYTHONDONTWRITEBYTECODE=1 python3 tools/release/validate_docs_compat.py --evidence /tmp/alk-code-review-docs-compat.json
- git diff --cached --check
- staged safety scan for local paths, secrets, and ignored task/work artifacts