### PR TITLE
chore: ignore .alk/ local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ htmlcov/
 
 # Local lifecycle authority material and generated evidence are never committed.
 .agent-lifecycle-authority/
+.alk/
 plans/standalone-v1/evidence/
 plans/standalone-v1/workflow/validation/
 plans/standalone-v1/workflow/gates/


### PR DESCRIPTION
Add `.alk/` to `.gitignore` (local ALK runtime/state directory, never committed) alongside `.agent-lifecycle-authority/`.