### PR TITLE
fix: load OpenCode adapter plugin

### DIFF
--- a/adapters/opencode/plugins/agent-lifecycle-kit.js
+++ b/adapters/opencode/plugins/agent-lifecycle-kit.js
@@ -1,7 +1,12 @@
-export default {
+// OpenCode's legacy plugin loader consumes exported functions.  ALK keeps its
+// lifecycle semantics in the shared core and skills, so this projection only
+// establishes a valid, side-effect-free host plugin boundary.
+export const AgentLifecycleKit = async () => ({});
+
+AgentLifecycleKit.alkMetadata = Object.freeze({
   name: "agent-lifecycle-kit",
   maturity: "VERIFIED",
   descriptor: "../adapter.descriptor.json",
   unsupportedOperationPolicy: "fail-closed",
   coreSemantics: "delegated-to-agent-lifecycle-core"
-};
+});

--- a/tests/adapters/test_host_adapters.py
+++ b/tests/adapters/test_host_adapters.py
@@ -112,6 +112,8 @@ class HostAdapterTests(unittest.TestCase):
                     manifest = load_json(adapter_root / config["nativeManifest"])
                     self.assertEqual(manifest["plugin"], ["./plugins/agent-lifecycle-kit.js"])
                     launcher = (adapter_root / "plugins/agent-lifecycle-kit.js").read_text(encoding="utf-8")
+                    self.assertIn("export const AgentLifecycleKit = async", launcher)
+                    self.assertNotIn("export default {", launcher)
                     self.assertIn("agent-lifecycle-kit", launcher)
                     self.assertIn("fail-closed", launcher)
                 elif config.get("capabilityOnly"):


### PR DESCRIPTION
## Что изменено

Исправлен экспорт плагина OpenCode. Legacy-загрузчик OpenCode ожидает экспортируемую функцию, а прежний объект приводил к ошибке Plugin export is not a function. Теперь плагин экспортирует безопасную функцию без побочных эффектов и сохраняет метаданные ALK.

## Проверки

- node --check adapters/opencode/plugins/agent-lifecycle-kit.js
- 25 тестов адаптеров и контрактов: OK
- реальный запуск OpenCode с zai-coding-plan/glm-5.2 в обычном и JSON-режиме: OK

## Версионирование

Изменение требует отдельной патч-версии 1.63.1, потому что исправляет опубликованный runtime-артефакт. Обновление версии и публикационные манифесты будут оформлены отдельным релизным изменением после слияния этого PR.