### PR TITLE
chore(release): prepare v1.63.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/avksp/agent-lifecycle-kit.git",
-        "ref": "v1.63.0"
+        "ref": "v1.63.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
       "source": {
         "source": "github",
         "repo": "avksp/agent-lifecycle-kit",
-        "ref": "v1.63.0"
+        "ref": "v1.63.1"
       },
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.63.0",
+      "version": "1.63.1",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
-    "version": "1.63.0"
+    "version": "1.63.1"
   },
   "plugins": [
     {
       "name": "agent-lifecycle-kit",
       "source": ".",
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.63.0",
+      "version": "1.63.1",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - No changes yet.
 
+## 1.63.1 - 2026-08-12
+
+- Fixed the OpenCode adapter plugin export so the legacy OpenCode loader can
+  load the plugin as a valid function.
+- Kept the OpenCode projection side-effect-free and delegated lifecycle
+  behavior to the shared Agent Lifecycle Kit core.
+
 ## 1.63.0 - 2026-08-12
 
 - Added a read-only `audit package` command that checks an ALK plan directory,

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ agent-lifecycle start --adapter <adapter-id> --text "Draft a reviewed implementa
 Choose `<adapter-id>` from the [adapter support matrix](docs/adapters/support-matrix.md).
 
 The official [PyPI package](https://pypi.org/project/agent-lifecycle-kit/) supports Python 3.11-3.14.
-Install the exact release with `python -m pip install agent-lifecycle-kit==1.63.0`.
+Install the exact release with `python -m pip install agent-lifecycle-kit==1.63.1`.
 
 Use [Quickstart](docs/guides/quickstart.md), [project profile init](docs/reference/project-workflow-profile.md), [task workflows](docs/guides/how-alk-works.md),
 [workflow customization and execution controls](docs/reference/workflow-customization.md),

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "Lifecycle skills and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "Provider-neutral lifecycle kit and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/cursor/.cursor-plugin/plugin.json
+++ b/adapters/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "Agent lifecycle planning, budgeted execution, adapter conformance, audit, and final proof for Cursor.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ that result. It is host-neutral and does not depend on a source project.
 ## Quick start
 
 - Official PyPI package for Python 3.11-3.14:
-  `python -m pip install agent-lifecycle-kit==1.63.0` from
+  `python -m pip install agent-lifecycle-kit==1.63.1` from
   [agent-lifecycle-kit](https://pypi.org/project/agent-lifecycle-kit/).
 - One safe entrypoint: `agent-lifecycle start --adapter <adapter-id> --file task.md`.
 - [Quickstart](guides/quickstart.md)

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ supports Python 3.11-3.14. When the package is available for the requested
 version, install the exact semantic version:
 
 ```bash
-python -m pip install agent-lifecycle-kit==1.63.0
+python -m pip install agent-lifecycle-kit==1.63.1
 agent-lifecycle version
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,7 +15,7 @@ Python 3.11-3.14 is supported. Install the exact release from the official
 [PyPI project](https://pypi.org/project/agent-lifecycle-kit/):
 
 ```bash
-  python -m pip install agent-lifecycle-kit==1.63.0
+  python -m pip install agent-lifecycle-kit==1.63.1
 ```
 
 ## Foundation

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -17,10 +17,10 @@ OpenInterpreter, Pi, Grok Build и других. Ядро не зависит о
 соразмерным уровнем контроля. Служебные шаги занимают только необходимое место,
 а основное время остаётся на исследование, реализацию и проверку продукта.
 
-**Лицензия:** Apache-2.0 · **Версия:** 1.63.0 · **Python:** 3.11-3.14
+**Лицензия:** Apache-2.0 · **Версия:** 1.63.1 · **Python:** 3.11-3.14
 
 ## Быстрый старт
-Официальный [пакет в PyPI](https://pypi.org/project/agent-lifecycle-kit/) для Python 3.11-3.14: `python -m pip install agent-lifecycle-kit==1.63.0`.
+Официальный [пакет в PyPI](https://pypi.org/project/agent-lifecycle-kit/) для Python 3.11-3.14: `python -m pip install agent-lifecycle-kit==1.63.1`.
 Из исходного дерева:
 
 ```bash

--- a/docs/ru/quickstart.md
+++ b/docs/ru/quickstart.md
@@ -34,7 +34,7 @@ PYTHONPATH=src python -m agent_lifecycle version
 устанавливайте точную семантическую версию:
 
 ```bash
-python -m pip install agent-lifecycle-kit==1.63.0
+python -m pip install agent-lifecycle-kit==1.63.1
 agent-lifecycle version
 ```
 

--- a/docs/ru/reference/cli.md
+++ b/docs/ru/reference/cli.md
@@ -14,7 +14,7 @@ JSON, чтобы результат можно было проверять ав�
 [проекта в PyPI](https://pypi.org/project/agent-lifecycle-kit/):
 
 ```bash
-python -m pip install agent-lifecycle-kit==1.63.0
+python -m pip install agent-lifecycle-kit==1.63.1
 ```
 
 ## Основа

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-lifecycle-kit"
-version = "1.63.0"
+version = "1.63.1"
 description = "Provider-neutral lifecycle control layer that helps coding agents plan, execute, validate, and prove software tasks to completion."
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/release/notes/v1.63.1.md
+++ b/release/notes/v1.63.1.md
@@ -1,0 +1,28 @@
+# Agent Lifecycle Kit v1.63.1
+
+Status: source release.
+
+This patch release fixes the OpenCode adapter plugin projection. OpenCode's
+legacy plugin loader expects an exported function; the previous projection
+exported a plain object and could fail with `Plugin export is not a function`.
+
+## Changes
+
+- Exported a valid, asynchronous OpenCode plugin function.
+- Preserved the plugin metadata used by ALK adapter inspection.
+- Kept the host projection side-effect-free; lifecycle behavior remains in the
+  shared Agent Lifecycle Kit core and skills.
+- Updated package, plugin, marketplace, and installation metadata to `1.63.1`.
+
+## Validation
+
+- JavaScript syntax check passed.
+- Adapter and publication contract tests passed.
+- OpenCode was run with `zai-coding-plan/glm-5.2` in default and JSON output
+  modes.
+
+## Claims
+
+- Adapter maturity changes: none.
+- Production promotion claimed: false.
+- Public directory or marketplace approval claimed: false.

--- a/src/agent_lifecycle/_version.py
+++ b/src/agent_lifecycle/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.63.0"
+__version__ = "1.63.1"

--- a/tests/package/test_foundation.py
+++ b/tests/package/test_foundation.py
@@ -18,7 +18,7 @@ class FoundationTests(unittest.TestCase):
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
         project = pyproject["project"]
         self.assertEqual(project["name"], "agent-lifecycle-kit")
-        self.assertEqual(project["version"], "1.63.0")
+        self.assertEqual(project["version"], "1.63.1")
         self.assertEqual(project["requires-python"], ">=3.11,<3.15")
         self.assertEqual(project["license"]["text"], "Apache-2.0")
         self.assertEqual(project["dependencies"], [])
@@ -73,7 +73,7 @@ class FoundationTests(unittest.TestCase):
         self.assertEqual(lock["requires-python"], ">=3.11, <3.15")
         packages = {package["name"]: package for package in lock["package"]}
         self.assertIn("agent-lifecycle-kit", packages)
-        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.63.0")
+        self.assertEqual(packages["agent-lifecycle-kit"]["version"], "1.63.1")
 
     def test_foundation_ci_uses_stdlib_unittest(self) -> None:
         pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11, <3.15"
 
 [[package]]
 name = "agent-lifecycle-kit"
-version = "1.63.0"
+version = "1.63.1"
 source = { editable = "." }


### PR DESCRIPTION
## Release 1.63.1

This patch release fixes the OpenCode adapter plugin projection.

### Changes

- Export a valid asynchronous OpenCode plugin function for the legacy loader.
- Preserve ALK adapter metadata and keep the host projection side-effect-free.
- Keep lifecycle behavior delegated to the shared Agent Lifecycle Kit core.
- Synchronize package, plugin, marketplace, documentation, and installation metadata to 1.63.1.

### Validation

- 1,026 unit and contract tests passed.
- Publication version validation passed for 1.63.1 / v1.63.1.
- Documentation compatibility validation passed.
- Wheel and source distribution packaging smoke passed.
- OpenCode plugin syntax validation passed.

The GitHub Release description will use release/notes/v1.63.1.md after this PR is merged.