### PR TITLE
chore(deps): align CodeQL actions at v4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: python
-      - uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7


### PR DESCRIPTION
Update both CodeQL workflow actions to the same immutable v4.37.7 revision.

The two Dependabot PRs #126 and #128 update init and analyze separately, which leaves the workflow with incompatible action versions. This PR applies the paired update atomically.

Validation:
- focused CI security tests: PASS
- validate_ci_security: PASS, 0 blockers
- no runtime or publication changes.