### PR TITLE
fix(redaction): preserve public URLs in receipts

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/avksp/agent-lifecycle-kit.git",
-        "ref": "v1.81.0"
+        "ref": "v1.81.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,10 @@
       "source": {
         "source": "github",
         "repo": "avksp/agent-lifecycle-kit",
-        "ref": "v1.81.0"
+        "ref": "v1.81.1"
       },
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.81.0",
+      "version": "1.81.1",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
-    "version": "1.81.0"
+    "version": "1.81.1"
   },
   "plugins": [
     {
       "name": "agent-lifecycle-kit",
       "source": ".",
       "description": "Reviewed SDD planning, budgeted execution, adapter conformance, implementation audit, and final proof.",
-      "version": "1.81.0",
+      "version": "1.81.1",
       "author": {
         "name": "Agent Lifecycle Kit contributors"
       },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Provider-neutral lifecycle kit for reviewed SDD planning, budgeted execution, adapter conformance, independent audits, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - No changes yet.
 
+## 1.81.1 - 2026-08-24
+
+- Preserved ordinary HTTP(S) evidence URLs during shared redaction while
+  retaining local-path, file-URI, bearer and standalone-token protection.
+- Added redaction for URL userinfo credentials and sensitive query values with
+  substitution-accurate counters across research and receipt surfaces.
+- Updated package, plugin, marketplace and installation metadata for the
+  1.81.1 patch release.
+
 ## 1.81.0 - 2026-08-23
 
 - Added `workflow task-rework` for authorized, bounded remediation after an

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ALK provides a verifiable finish for external-agent work with proportionate cont
 ## Quick start
 Start with [install ALK and make the first run](docs/guides/install-and-first-run.md).
 
-It includes macOS, Linux and Windows instructions, Python 3.11-3.14, [PyPI](https://pypi.org/project/agent-lifecycle-kit/) installation with `python -m pip install agent-lifecycle-kit==1.81.0`, and common `agent-lifecycle version` errors.
+It includes macOS, Linux and Windows instructions, Python 3.11-3.14, [PyPI](https://pypi.org/project/agent-lifecycle-kit/) installation with `python -m pip install agent-lifecycle-kit==1.81.1`, and common `agent-lifecycle version` errors.
 
 For a quick start, run:
 

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Lifecycle skills and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Provider-neutral lifecycle kit and adapter metadata for reviewed planning, budgeted execution, adapter conformance, audit, and final proof.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/adapters/cursor/.cursor-plugin/plugin.json
+++ b/adapters/cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-lifecycle-kit",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "description": "Agent lifecycle planning, budgeted execution, adapter conformance, audit, and final proof for Cursor.",
   "author": {
     "name": "Agent Lifecycle Kit contributors"

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ that result. It is host-neutral and does not depend on a source project.
 - [Agent Plugins client qualification](reference/agent-plugin-qualification.md)
 - [Commands by task](guides/commands-by-task.md)
 - Official PyPI package for Python 3.11-3.14:
-  `python -m pip install agent-lifecycle-kit==1.81.0` from
+  `python -m pip install agent-lifecycle-kit==1.81.1` from
   [agent-lifecycle-kit](https://pypi.org/project/agent-lifecycle-kit/).
 - One safe entrypoint: `agent-lifecycle start --adapter <adapter-id> --file task.md`.
 - [Quickstart](guides/quickstart.md)

--- a/docs/guides/install-and-first-run.md
+++ b/docs/guides/install-and-first-run.md
@@ -77,7 +77,7 @@ Use an isolated environment for a package installation as well.
 python3 -m venv ~/.venvs/alk
 source ~/.venvs/alk/bin/activate
 python -m pip install --upgrade pip
-python -m pip install agent-lifecycle-kit==1.81.0
+python -m pip install agent-lifecycle-kit==1.81.1
 python -m agent_lifecycle version
 agent-lifecycle version
 ```
@@ -88,7 +88,7 @@ agent-lifecycle version
 py -m venv "$HOME\venvs\alk"
 & "$HOME\venvs\alk\Scripts\Activate.ps1"
 python -m pip install --upgrade pip
-python -m pip install agent-lifecycle-kit==1.81.0
+python -m pip install agent-lifecycle-kit==1.81.1
 python -m agent_lifecycle version
 agent-lifecycle version
 ```
@@ -188,7 +188,7 @@ Choose one host and follow its adapter page. The common sequence is:
 Codex:
 
 ```bash
-codex plugin marketplace add avksp/agent-lifecycle-kit --ref v1.81.0
+codex plugin marketplace add avksp/agent-lifecycle-kit --ref v1.81.1
 codex plugin add agent-lifecycle-kit@agent-lifecycle-kit
 codex plugin list
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,7 @@ Python 3.11-3.14 is supported. Install the exact release from the official
 [PyPI project](https://pypi.org/project/agent-lifecycle-kit/):
 
 ```bash
-  python -m pip install agent-lifecycle-kit==1.81.0
+  python -m pip install agent-lifecycle-kit==1.81.1
 ```
 
 ## Error and resource contracts

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -18,7 +18,7 @@ OpenInterpreter, Pi, Grok Build и других. Ядро не зависит о
 подтверждения, а основное время остаётся на исследование, реализацию и проверку
 продукта.
 
-**Лицензия:** Apache-2.0 · **Версия:** 1.81.0 · Python 3.11-3.14
+**Лицензия:** Apache-2.0 · **Версия:** 1.81.1 · Python 3.11-3.14
 
 Английская документация: [английская версия на GitHub](https://github.com/avksp/agent-lifecycle-kit/blob/main/README.md).
 
@@ -28,7 +28,7 @@ OpenInterpreter, Pi, Grok Build и других. Ядро не зависит о
 
 Описание переносимого пакета навыков находится в разделе [переносимый пакет Agent Plugins](reference/agent-plugins.md), проверка установленного пакета - в разделе [проверка Agent Plugins в клиентах](reference/agent-plugin-qualification.md), а необязательный контроль жизненного цикла адаптера - в [отдельном справочнике](adapters/lifecycle-control.md). Сейчас комплектные адаптеры публикуют `GUIDANCE_ONLY` и `NO_RECOMMENDATION`, а управляемый запуск сохраняет статус `WRAPPER_ONLY`.
 
-В нём есть варианты для macOS, Linux и Windows, установка из [PyPI](https://pypi.org/project/agent-lifecycle-kit/) командой `python -m pip install agent-lifecycle-kit==1.81.0` и разбор ошибок команды `agent-lifecycle version`.
+В нём есть варианты для macOS, Linux и Windows, установка из [PyPI](https://pypi.org/project/agent-lifecycle-kit/) командой `python -m pip install agent-lifecycle-kit==1.81.1` и разбор ошибок команды `agent-lifecycle version`.
 
 Для быстрого старта выполните:
 

--- a/docs/ru/guides/install-and-first-run.md
+++ b/docs/ru/guides/install-and-first-run.md
@@ -78,7 +78,7 @@ Set-Location agent-lifecycle-kit
 python3 -m venv ~/.venvs/alk
 source ~/.venvs/alk/bin/activate
 python -m pip install --upgrade pip
-python -m pip install agent-lifecycle-kit==1.81.0
+python -m pip install agent-lifecycle-kit==1.81.1
 python -m agent_lifecycle version
 agent-lifecycle version
 ```
@@ -89,7 +89,7 @@ agent-lifecycle version
 py -m venv "$HOME\venvs\alk"
 & "$HOME\venvs\alk\Scripts\Activate.ps1"
 python -m pip install --upgrade pip
-python -m pip install agent-lifecycle-kit==1.81.0
+python -m pip install agent-lifecycle-kit==1.81.1
 python -m agent_lifecycle version
 agent-lifecycle version
 ```
@@ -187,7 +187,7 @@ agent-lifecycle start \
 Codex:
 
 ```bash
-codex plugin marketplace add avksp/agent-lifecycle-kit --ref v1.81.0
+codex plugin marketplace add avksp/agent-lifecycle-kit --ref v1.81.1
 codex plugin add agent-lifecycle-kit@agent-lifecycle-kit
 codex plugin list
 ```

--- a/docs/ru/reference/cli.md
+++ b/docs/ru/reference/cli.md
@@ -18,7 +18,7 @@ ALK и первый запуск](../guides/install-and-first-run.md). Указ�
 [проекта в PyPI](https://pypi.org/project/agent-lifecycle-kit/):
 
 ```bash
-python -m pip install agent-lifecycle-kit==1.81.0
+python -m pip install agent-lifecycle-kit==1.81.1
 ```
 
 ## Контракты ошибок и ресурсов

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-lifecycle-kit"
-version = "1.81.0"
+version = "1.81.1"
 description = "Provider-neutral lifecycle control layer that helps coding agents plan, execute, validate, and prove software tasks to completion."
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/src/agent_lifecycle/_version.py
+++ b/src/agent_lifecycle/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "1.81.0"
+__version__ = "1.81.1"

--- a/src/agent_lifecycle/contracts/redaction.py
+++ b/src/agent_lifecycle/contracts/redaction.py
@@ -117,13 +117,13 @@ def redact_value(value: Any) -> tuple[Any, bool]:
             changed = changed or nested_changed
         return result, changed
     if isinstance(value, list):
-        result = []
+        result_list: list[Any] = []
         changed = False
         for item in value:
             nested, nested_changed = redact_value(item)
-            result.append(nested)
+            result_list.append(nested)
             changed = changed or nested_changed
-        return result, changed
+        return result_list, changed
     if isinstance(value, str):
         return redact_text(value)
     return value, False

--- a/src/agent_lifecycle/contracts/redaction.py
+++ b/src/agent_lifecycle/contracts/redaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
 REDACTED_VALUE = "<redacted>"
 LOCAL_PATH_REDACTION = "<local-path>"
@@ -55,6 +56,7 @@ _KEY_VALUE = re.compile(
     r"(?P<key>[\"']?[A-Za-z][A-Za-z0-9_.-]*[\"']?)(?P<separator>\s*[:=]\s*)(?P<value>Bearer\s+[^\s,;}\]]+|\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^\s,;}\]]+)",
     re.IGNORECASE,
 )
+_HTTP_URL = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
 _LOCAL_PATH = re.compile(
     r"(?<![A-Za-z0-9_.-])(?:"
     r"[A-Za-z]:[\\/](?:[A-Za-z0-9._~@+ -]+[\\/])*[A-Za-z0-9._~@+ -]+|"
@@ -77,16 +79,15 @@ def redact_text(value: str) -> tuple[str, bool]:
 def redact_text_with_stats(value: str) -> tuple[str, bool, dict[str, int]]:
     """Redact shared forms and expose coarse category counts to importers."""
 
-    redacted = _PRIVATE_KEY.sub(REDACTED_VALUE, value)
-    secret_count = len(_PRIVATE_KEY.findall(value))
-    redacted = _BEARER.sub(f"Bearer {REDACTED_VALUE}", redacted)
-    secret_count += len(_BEARER.findall(value))
-    redacted = _BARE_TOKEN.sub(REDACTED_VALUE, redacted)
-    secret_count += len(_BARE_TOKEN.findall(value))
-    redacted, assignment_count = _KEY_VALUE.subn(_replace_sensitive_assignment, redacted)
-    secret_count += assignment_count
+    redacted, urls, url_secret_count = _protect_http_urls(value)
+    redacted, private_key_count = _replace_matches(_PRIVATE_KEY, redacted, REDACTED_VALUE)
+    redacted, bearer_count = _replace_matches(_BEARER, redacted, f"Bearer {REDACTED_VALUE}")
+    redacted, token_count = _replace_matches(_BARE_TOKEN, redacted, REDACTED_VALUE)
+    redacted, assignment_count = _redact_sensitive_assignments(redacted)
+    secret_count = url_secret_count + private_key_count + bearer_count + token_count + assignment_count
     path_count = len(_LOCAL_PATH.findall(redacted))
     redacted = _LOCAL_PATH.sub(LOCAL_PATH_REDACTION, redacted)
+    redacted = _restore_http_urls(redacted, urls)
     return redacted, redacted != value, {
         "secretLikeMarkersRedacted": secret_count,
         "localPathsRedacted": path_count,
@@ -96,7 +97,8 @@ def redact_text_with_stats(value: str) -> tuple[str, bool, dict[str, int]]:
 def contains_local_absolute_path(value: str) -> bool:
     """Return whether text contains a local absolute path or file URI."""
 
-    return bool(_LOCAL_PATH.search(value))
+    protected = _HTTP_URL.sub("__alk_http_url__", value)
+    return bool(_LOCAL_PATH.search(protected))
 
 
 def redact_value(value: Any) -> tuple[Any, bool]:
@@ -141,6 +143,92 @@ def _replace_sensitive_assignment(match: re.Match[str]) -> str:
     value = match.group("value")
     replacement = _quoted_redaction(value)
     return f"{key}{match.group('separator')}{replacement}"
+
+
+def _replace_matches(pattern: re.Pattern[str], value: str, replacement: str) -> tuple[str, int]:
+    """Apply a fixed replacement and count only matches in the input."""
+
+    matches = list(pattern.finditer(value))
+    return pattern.sub(replacement, value), len(matches)
+
+
+def _redact_sensitive_assignments(value: str) -> tuple[str, int]:
+    """Redact sensitive assignments without counting safe key/value pairs."""
+
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        replacement = _replace_sensitive_assignment(match)
+        if replacement != match.group(0):
+            count += 1
+        return replacement
+
+    return _KEY_VALUE.sub(replace, value), count
+
+
+def _protect_http_urls(value: str) -> tuple[str, list[str], int]:
+    """Redact secrets inside HTTP URLs while shielding their paths from path matching."""
+
+    urls: list[str] = []
+    secret_count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal secret_count
+        redacted, count = _redact_http_url(match.group(0))
+        urls.append(redacted)
+        secret_count += count
+        return f"__alk_http_url_{len(urls) - 1}__"
+
+    return _HTTP_URL.sub(replace, value), urls, secret_count
+
+
+def _restore_http_urls(value: str, urls: list[str]) -> str:
+    """Restore URL spans after non-URL path and assignment processing."""
+
+    for index, url in enumerate(urls):
+        value = value.replace(f"__alk_http_url_{index}__", url)
+    return value
+
+
+def _redact_http_url(value: str) -> tuple[str, int]:
+    """Redact URL credentials, sensitive query values and provider tokens."""
+
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return value, 0
+    netloc = parsed.netloc
+    secret_count = 0
+    if "@" in netloc:
+        _userinfo, host = netloc.rsplit("@", 1)
+        netloc = f"{REDACTED_VALUE}@{host}"
+        secret_count += 1
+    query, query_count = _redact_url_query(parsed.query)
+    fragment, fragment_count = _redact_url_query(parsed.fragment)
+    secret_count += query_count + fragment_count
+    redacted = urlunsplit((parsed.scheme, netloc, parsed.path, query, fragment))
+    redacted, private_key_count = _replace_matches(_PRIVATE_KEY, redacted, REDACTED_VALUE)
+    redacted, bearer_count = _replace_matches(_BEARER, redacted, f"Bearer {REDACTED_VALUE}")
+    redacted, token_count = _replace_matches(_BARE_TOKEN, redacted, REDACTED_VALUE)
+    return redacted, secret_count + private_key_count + bearer_count + token_count
+
+
+def _redact_url_query(value: str) -> tuple[str, int]:
+    """Redact values for sensitive URL query or fragment keys without normalizing safe text."""
+
+    if not value:
+        return value, 0
+    parts = value.split("&")
+    count = 0
+    for index, part in enumerate(parts):
+        if "=" not in part:
+            continue
+        key, _raw_value = part.split("=", 1)
+        if is_sensitive_key(unquote_plus(key).strip("\"'")):
+            parts[index] = f"{key}={REDACTED_VALUE}"
+            count += 1
+    return "&".join(parts), count
 
 
 def _quoted_redaction(value: str) -> str:

--- a/tests/contracts/test_process_redaction.py
+++ b/tests/contracts/test_process_redaction.py
@@ -17,6 +17,23 @@ class ProcessRedactionContractTests(unittest.TestCase):
         self.assertNotIn(posix_path, redacted)
         self.assertNotIn("C:\\Users\\example", redacted)
 
+    def test_process_output_preserves_public_urls(self) -> None:
+        value = "See https://github.com/avksp/agent-lifecycle-kit/docs and http://example.com/public"
+
+        redacted, changed = redact_process_text(value)
+
+        self.assertFalse(changed)
+        self.assertEqual(redacted, value)
+
+    def test_process_output_redacts_url_secrets(self) -> None:
+        value = "https://user:password@example.com/path?api_key=topsecret"
+
+        redacted, changed = redact_process_text(value)
+
+        self.assertTrue(changed)
+        self.assertNotIn("password", redacted)
+        self.assertNotIn("topsecret", redacted)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/contracts/test_redaction.py
+++ b/tests/contracts/test_redaction.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from agent_lifecycle.contracts.redaction import REDACTED_VALUE, redact_text, redact_value
+from agent_lifecycle.contracts.redaction import REDACTED_VALUE, redact_text, redact_text_with_stats, redact_value
 
 
 class ReceiptRedactionTests(unittest.TestCase):
@@ -82,6 +82,35 @@ class ReceiptRedactionTests(unittest.TestCase):
         for value in values:
             self.assertNotIn(value, redacted)
         self.assertGreaterEqual(redacted.count(REDACTED_VALUE), len(values))
+
+    def test_redact_text_preserves_public_http_urls(self) -> None:
+        public_path = "/" + "Users/public"
+        value = "See https://github.com/avksp/agent-lifecycle-kit and http://example.com" + public_path
+
+        redacted, applied, stats = redact_text_with_stats(value)
+
+        self.assertFalse(applied)
+        self.assertEqual(redacted, value)
+        self.assertEqual(stats["secretLikeMarkersRedacted"], 0)
+        self.assertEqual(stats["localPathsRedacted"], 0)
+
+    def test_redact_text_redacts_url_credentials_and_sensitive_query_values(self) -> None:
+        value = "https://user:password@example.com/path?api_key=supersecret123&safe=1"
+
+        redacted, applied = redact_text(value)
+
+        self.assertTrue(applied)
+        self.assertEqual(redacted, "https://<redacted>@example.com/path?api_key=<redacted>&safe=1")
+        self.assertNotIn("password", redacted)
+        self.assertNotIn("supersecret123", redacted)
+
+    def test_redact_text_keeps_non_sensitive_url_query_values(self) -> None:
+        value = "https://example.com/path?search=public&redirect=https%3A%2F%2Fexample.com"
+
+        redacted, applied = redact_text(value)
+
+        self.assertFalse(applied)
+        self.assertEqual(redacted, value)
 
 
 if __name__ == "__main__":

--- a/tests/host_protocol/test_receipts.py
+++ b/tests/host_protocol/test_receipts.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import unittest
+
+from agent_lifecycle.host_protocol.receipts import normalize_host_operation_receipt
+
+
+class HostOperationReceiptRedactionTests(unittest.TestCase):
+    def test_public_url_is_preserved_in_host_receipt(self) -> None:
+        private_path = "/" + "Users/operator/private.log"
+        payload = {
+            "schemaVersion": "agent-host-operation-receipt.v1",
+            "operationId": "op-1",
+            "capability": "inspect",
+            "status": "PASS",
+            "outputs": [
+                {"message": "see https://github.com/avksp/agent-lifecycle-kit/docs"},
+                {"path": private_path},
+            ],
+            "usage": {},
+        }
+
+        receipt = normalize_host_operation_receipt(payload)
+
+        self.assertEqual(receipt["outputs"][0]["message"], "see https://github.com/avksp/agent-lifecycle-kit/docs")
+        self.assertNotIn(private_path, str(receipt))
+        self.assertEqual(receipt["usage"]["receiptRedaction"]["secretValuesStored"], False)
+
+    def test_url_credentials_and_sensitive_query_values_are_redacted(self) -> None:
+        payload = {
+            "schemaVersion": "agent-host-operation-receipt.v1",
+            "operationId": "op-2",
+            "capability": "inspect",
+            "status": "PASS",
+            "outputs": [{"message": "https://user:password@example.com/path?api_key=topsecret&ok=1"}],
+            "usage": {},
+        }
+
+        receipt = normalize_host_operation_receipt(payload)
+        message = receipt["outputs"][0]["message"]
+
+        self.assertNotIn("password", message)
+        self.assertNotIn("topsecret", message)
+        self.assertIn("example.com/path?api_key=<redacted>&ok=1", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/research/test_research_validation.py
+++ b/tests/research/test_research_validation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import unittest
+
+from agent_lifecycle.research.evidence import package_digest
+from agent_lifecycle.research.validation import validate_evidence_package
+
+
+def _package(locator: str) -> dict:
+    package = {
+        "schemaVersion": "agent-research-evidence-package.v1",
+        "packageId": "research-redaction",
+        "status": "PASS",
+        "sources": [
+            {
+                "schemaVersion": "agent-research-source.v1",
+                "sourceId": "source-1",
+                "kind": "web",
+                "locator": {"kind": "url", "value": locator, "start": 0, "end": 0},
+                "title": "Public source",
+                "status": "reviewed",
+                "sourceDigest": "a" * 64,
+                "snapshotDigest": None,
+                "metadata": {},
+                "redactionStatus": {"status": "PASS"},
+                "sourceOfTruth": False,
+                "rawContentStored": False,
+                "productionPromotionClaimed": False,
+            }
+        ],
+        "claims": [],
+        "citations": [],
+        "provenance": [],
+        "resourceCaps": {"maxEvidenceBytes": 33_554_432},
+        "redaction": {"status": "PASS", "rawContentStored": False},
+        "sourceOfTruth": False,
+        "blockers": [],
+        "productionPromotionClaimed": False,
+    }
+    package["packageDigest"] = package_digest(package)
+    return package
+
+
+class ResearchValidationRedactionTests(unittest.TestCase):
+    def test_public_url_locator_is_accepted(self) -> None:
+        validation = validate_evidence_package(_package("https://github.com/avksp/agent-lifecycle-kit"))
+
+        self.assertEqual(validation["status"], "PASS")
+
+    def test_local_absolute_locator_remains_rejected(self) -> None:
+        private_path = "/" + "Users/private/source.md"
+        validation = validate_evidence_package(_package(private_path))
+
+        self.assertEqual(validation["status"], "FAIL")
+        codes = {item["code"] for item in validation["blockers"]}
+        self.assertIn("research-locator-private-path", codes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11, <3.15"
 
 [[package]]
 name = "agent-lifecycle-kit"
-version = "1.81.0"
+version = "1.81.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Release 1.81.1

## Summary

Fix shared redaction so ordinary HTTP(S) evidence URLs remain readable without weakening secret or local-path protection.

## Highlights

- Public URL paths are no longer mistaken for local absolute paths.
- Process output, adapter and plugin receipts, research evidence, host context events, external context, Review Mesh results, context checkpoints and stores, lifecycle-control and Thread Bridge payloads, benchmark reporting and privacy-preserving audit samples share the corrected behavior.
- Existing local-path, file-URI, bearer and standalone-token protections are preserved; URL userinfo and sensitive query values gain explicit redaction.
- Redaction counters report only transformations that actually occurred.

## Compatibility

This patch preserves Release 1.81 contracts and authority boundaries. It adds no network access or runtime dependency.
