### PR TITLE
chore(deps): update CodeQL action atomically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      codeql:
+        patterns:
+          - github/codeql-action/*
     open-pull-requests-limit: 10
   - package-ecosystem: pip
     directory: "/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
-      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/tests/release/test_ci_security_validator.py
+++ b/tests/release/test_ci_security_validator.py
@@ -42,6 +42,23 @@ class CiSecurityValidatorTests(unittest.TestCase):
         self.assertEqual(result["status"], "FAIL")
         self.assertIn("action-reference-not-immutable", {item["code"] for item in result["blockers"]})
 
+    def test_mixed_codeql_action_revisions_are_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workflow_root = Path(tmp) / "workflows"
+            workflow_root.mkdir()
+            workflow = (ROOT / ".github/workflows/codeql.yml").read_text(encoding="utf-8")
+            mutated_workflow = re.sub(
+                r"(?m)^(\s*-\s+uses:\s+github/codeql-action/analyze)@[0-9a-f]{40}",
+                rf"\1@{'0' * 40}",
+                workflow,
+                count=1,
+            )
+            (workflow_root / "codeql.yml").write_text(mutated_workflow, encoding="utf-8")
+            result = validate_ci_security(workflow_root=workflow_root, tests_root=ROOT / "tests", repository_root=ROOT)
+
+        self.assertEqual(result["status"], "FAIL")
+        self.assertIn("codeql-action-revision-mismatch", {item["code"] for item in result["blockers"]})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/release/test_release_workflows.py
+++ b/tests/release/test_release_workflows.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import unittest
 import re
+import unittest
 from pathlib import Path
 
 
@@ -67,7 +67,11 @@ class ReleaseWorkflowTests(unittest.TestCase):
         dependabot = (ROOT / ".github/dependabot.yml").read_text(encoding="utf-8")
         self.assertIn("github/codeql-action/init@", codeql)
         self.assertIn("github/codeql-action/analyze@", codeql)
+        codeql_revisions = re.findall(r"github/codeql-action/(?:init|analyze)@([0-9a-f]{40})", codeql)
+        self.assertEqual(len(codeql_revisions), 2)
+        self.assertEqual(len(set(codeql_revisions)), 1)
         self.assertIn("package-ecosystem: github-actions", dependabot)
+        self.assertIn("github/codeql-action/*", dependabot)
         self.assertIn("package-ecosystem: pip", dependabot)
 
 

--- a/tools/release/validate_ci_security.py
+++ b/tools/release/validate_ci_security.py
@@ -118,9 +118,19 @@ def _validate_workflows(workflow_root: Path, repository_root: Path) -> dict[str,
         if path.name == "ci.yml" and "tests/security" not in text:
             workflow_blockers.append({"code": "security-suite-not-directly-run", "path": relative})
         if path.name == "codeql.yml":
-            for action in ("github/codeql-action/init", "github/codeql-action/analyze"):
+            codeql_actions = ("github/codeql-action/init", "github/codeql-action/analyze")
+            for action in codeql_actions:
                 if not any(item["action"] == action and item["status"] == "PASS" for item in action_checks):
                     workflow_blockers.append({"code": "codeql-action-missing-or-unpinned", "path": relative, "action": action})
+            revisions = {
+                item["revision"]
+                for item in action_checks
+                if item["action"] in codeql_actions and item["status"] == "PASS"
+            }
+            if len(revisions) > 1:
+                workflow_blockers.append(
+                    {"code": "codeql-action-revision-mismatch", "path": relative, "revisions": sorted(revisions)}
+                )
         status = "PASS" if not workflow_blockers else "FAIL"
         checks.append({"id": f"workflow:{relative}", "status": status, "actionCount": len(action_checks)})
         blockers.extend(workflow_blockers)


### PR DESCRIPTION
## Summary
- update both CodeQL init and analyze actions to the same v4.37.9 commit SHA
- group CodeQL actions in Dependabot so future updates arrive atomically
- reject mixed CodeQL action revisions in the CI security validator

## Validation
- full baseline-aware Python quality run: PASS (2039 tests)
- quality validation: PASS
- CI security validation: PASS
- targeted release/package tests: PASS
- YAML parse and git diff check: PASS

Replaces #161 and #162, whose one-sided updates produce an unsupported mixed CodeQL action version.